### PR TITLE
deduplication based on Pulsar

### DIFF
--- a/modules/alerts/src/main/scala/trading/alerts/Engine.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Engine.scala
@@ -1,14 +1,14 @@
 package trading.alerts
 
 import trading.commands.TradeCommand
-import trading.core.{ Conflicts, TradeEngine }
+import trading.core.TradeEngine
 import trading.domain.Alert.{ TradeAlert, TradeUpdate }
 import trading.domain.AlertType.*
 import trading.domain.TradingStatus.*
 import trading.domain.*
 import trading.events.TradeEvent
 import trading.lib.*
-import trading.state.{ DedupState, TradeState }
+import trading.state.TradeState
 
 import cats.MonadThrow
 import cats.syntax.all.*
@@ -17,57 +17,52 @@ object Engine:
   def fsm[F[_]: GenUUID: Logger: MonadThrow: Time](
       producer: Producer[F, Alert],
       ack: Consumer.MsgId => F[Unit]
-  ): FSM[F, (TradeState, DedupState), Consumer.Msg[TradeEvent], Unit] =
+  ): FSM[F, TradeState, Consumer.Msg[TradeEvent], Unit] =
     FSM {
-      case ((st @ TradeState(Off, _), ds), Consumer.Msg(msgId, _, TradeEvent.Started(_, cid, _))) =>
+      case (st @ TradeState(Off, _), Consumer.Msg(msgId, _, TradeEvent.Started(_, cid, _))) =>
         (GenUUID[F].make[AlertId], Time[F].timestamp).tupled.flatMap { (id, ts) =>
           val alert = TradeUpdate(id, cid, TradingStatus.On, ts)
-          (producer.send(alert) *> ack(msgId)).attempt.void.tupleLeft(st -> ds)
+          (producer.send(alert) *> ack(msgId)).attempt.void.tupleLeft(st)
         }
-      case ((st @ TradeState(On, _), ds), Consumer.Msg(msgId, _, TradeEvent.Stopped(_, cid, _))) =>
+      case (st @ TradeState(On, _), Consumer.Msg(msgId, _, TradeEvent.Stopped(_, cid, _))) =>
         (GenUUID[F].make[AlertId], Time[F].timestamp).tupled.flatMap { (id, ts) =>
           val alert = TradeUpdate(id, cid, TradingStatus.Off, ts)
-          (producer.send(alert) *> ack(msgId)).attempt.void.tupleLeft(st -> ds)
+          (producer.send(alert) *> ack(msgId)).attempt.void.tupleLeft(st)
         }
-      case ((st @ TradeState(On, _), ds), Consumer.Msg(msgId, _, TradeEvent.Started(_, _, _))) =>
-        (Logger[F].warn(s"Status already On") *> ack(msgId)).tupleLeft(st -> ds)
-      case ((st @ TradeState(Off, _), ds), Consumer.Msg(msgId, _, TradeEvent.Stopped(_, _, _))) =>
-        (Logger[F].warn(s"Status already Off") *> ack(msgId)).tupleLeft(st -> ds)
-      case ((st, ds), Consumer.Msg(msgId, _, TradeEvent.CommandRejected(_, _, _, _, _))) =>
-        ack(msgId).tupleLeft(st -> ds)
-      case ((st, ds), Consumer.Msg(msgId, _, TradeEvent.CommandExecuted(_, cid, command, _))) =>
-        Conflicts.dedup(ds)(command) match
-          case None =>
-            Logger[F].warn(s"Deduplicated Command ID: ${command.id.show}").tupleLeft(st -> ds)
-          case Some(cmd) =>
-            TradeCommand._Symbol.get(cmd).fold(ack(msgId).attempt.void.tupleLeft(st -> ds)) { symbol =>
-              val nst = TradeEngine.fsm.runS(st, cmd)
-              val p   = st.prices.get(symbol)
-              val c   = nst.prices.get(symbol)
+      case (st @ TradeState(On, _), Consumer.Msg(msgId, _, TradeEvent.Started(_, _, _))) =>
+        (Logger[F].warn(s"Status already On") *> ack(msgId)).tupleLeft(st)
+      case (st @ TradeState(Off, _), Consumer.Msg(msgId, _, TradeEvent.Stopped(_, _, _))) =>
+        (Logger[F].warn(s"Status already Off") *> ack(msgId)).tupleLeft(st)
+      case (st, Consumer.Msg(msgId, _, TradeEvent.CommandRejected(_, _, _, _, _))) =>
+        ack(msgId).tupleLeft(st)
+      case (st, Consumer.Msg(msgId, _, TradeEvent.CommandExecuted(_, cid, cmd, _))) =>
+        TradeCommand._Symbol.get(cmd).fold(ack(msgId).attempt.void.tupleLeft(st)) { symbol =>
+          val nst = TradeEngine.fsm.runS(st, cmd)
+          val p   = st.prices.get(symbol)
+          val c   = nst.prices.get(symbol)
 
-              val previousAskMax: AskPrice = p.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
-              val previousBidMax: BidPrice = p.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
-              val currentAskMax: AskPrice  = c.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
-              val currentBidMax: BidPrice  = c.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
+          val previousAskMax: AskPrice = p.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
+          val previousBidMax: BidPrice = p.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
+          val currentAskMax: AskPrice  = c.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
+          val currentBidMax: BidPrice  = c.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
 
-              val high: Price = c.map(_.high).getOrElse(Price(0.0))
-              val low: Price  = c.map(_.low).getOrElse(Price(0.0))
+          val high: Price = c.map(_.high).getOrElse(Price(0.0))
+          val low: Price  = c.map(_.low).getOrElse(Price(0.0))
 
-              // dummy logic to simulate the trading market
-              def alert(id: AlertId, ts: Timestamp): Alert =
-                if previousAskMax - currentAskMax > Price(0.3) then
-                  TradeAlert(id, cid, StrongBuy, symbol, currentAskMax, currentBidMax, high, low, ts)
-                else if previousAskMax - currentAskMax > Price(0.2) then
-                  TradeAlert(id, cid, Buy, symbol, currentAskMax, currentBidMax, high, low, ts)
-                else if currentBidMax - previousBidMax > Price(0.3) then
-                  TradeAlert(id, cid, StrongSell, symbol, currentAskMax, currentBidMax, high, low, ts)
-                else if currentBidMax - previousBidMax > Price(0.2) then
-                  TradeAlert(id, cid, Sell, symbol, currentAskMax, currentBidMax, high, low, ts)
-                else TradeAlert(id, cid, Neutral, symbol, currentAskMax, currentBidMax, high, low, ts)
+          // dummy logic to simulate the trading market
+          def alert(id: AlertId, ts: Timestamp): Alert =
+            if previousAskMax - currentAskMax > Price(0.3) then
+              TradeAlert(id, cid, StrongBuy, symbol, currentAskMax, currentBidMax, high, low, ts)
+            else if previousAskMax - currentAskMax > Price(0.2) then
+              TradeAlert(id, cid, Buy, symbol, currentAskMax, currentBidMax, high, low, ts)
+            else if currentBidMax - previousBidMax > Price(0.3) then
+              TradeAlert(id, cid, StrongSell, symbol, currentAskMax, currentBidMax, high, low, ts)
+            else if currentBidMax - previousBidMax > Price(0.2) then
+              TradeAlert(id, cid, Sell, symbol, currentAskMax, currentBidMax, high, low, ts)
+            else TradeAlert(id, cid, Neutral, symbol, currentAskMax, currentBidMax, high, low, ts)
 
-              (GenUUID[F].make[AlertId], Time[F].timestamp).tupled.flatMap { (id, ts) =>
-                val nds = Conflicts.update(ds)(cmd, ts)
-                (producer.send(alert(id, ts)) *> ack(msgId)).attempt.void.tupleLeft(nst -> nds)
-              }
-            }
+          (GenUUID[F].make[AlertId], Time[F].timestamp).tupled.flatMap { (id, ts) =>
+            (producer.send(alert(id, ts)) *> ack(msgId)).attempt.void.tupleLeft(nst)
+          }
+        }
     }

--- a/modules/core/src/main/scala/trading/core/Conflicts.scala
+++ b/modules/core/src/main/scala/trading/core/Conflicts.scala
@@ -6,6 +6,8 @@ import trading.state.{ DedupState, IdRegistry }
 
 import cats.syntax.all.*
 
+// Not used in the project but left here to demonstrate how deduplication could be
+// implemented for other brokers that do not support it natively (see also DedupRegistry).
 object Conflicts:
   def dedup(st: DedupState)(command: TradeCommand): Option[TradeCommand] =
     (!st.ids.map(_.id).contains(command.id)).guard[Option].as(command)

--- a/modules/core/src/main/scala/trading/core/dedup/DedupRegistry.scala
+++ b/modules/core/src/main/scala/trading/core/dedup/DedupRegistry.scala
@@ -12,6 +12,8 @@ import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.effect.{ Log, MkRedis }
 import dev.profunktor.redis4cats.{ Redis, RedisCommands }
 
+// Not used in the project but left here to demonstrate how deduplication could be
+// implemented for other brokers that do not support it natively (see also Conflicts).
 trait DedupRegistry[F[_]]:
   def get: F[DedupState]
   def save(state: DedupState): F[Unit]

--- a/modules/domain/shared/src/main/scala/trading/domain/AlertType.scala
+++ b/modules/domain/shared/src/main/scala/trading/domain/AlertType.scala
@@ -1,6 +1,6 @@
 package trading.domain
 
-import cats.Show
+import cats.{ Eq, Show }
 // FIXME: importing * does not work
 import cats.derived.semiauto.{ derived, product }
 import cats.syntax.all.*
@@ -10,6 +10,8 @@ enum AlertType derives Show:
   case StrongBuy, StrongSell, Neutral, Buy, Sell
 
 object AlertType:
+  given Eq[AlertType] = Eq.fromUniversalEquals
+
   given Decoder[AlertType] = Decoder[String].emap[AlertType] { str =>
     Either.catchNonFatal(valueOf(str)).leftMap(_.getMessage)
   }

--- a/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
@@ -3,7 +3,7 @@ package trading.events
 import trading.commands.TradeCommand
 import trading.domain.{ given, * }
 
-import cats.{ Applicative, Show }
+import cats.{ Applicative, Eq, Show }
 // FIXME: importing all `given` yield ambiguous implicits
 import cats.derived.semiauto.{ derived, product }
 import cats.syntax.all.*
@@ -42,6 +42,9 @@ object TradeEvent:
       cid: CorrelationId,
       createdAt: Timestamp
   ) extends TradeEvent
+
+  // EventId and Timestamp are regenerated when reprocessed so we don't consider them for deduplication.
+  given Eq[TradeEvent] = Eq.and(Eq.by(_.cid), Eq.by(_Command.get))
 
   val _Command =
     Getter[TradeEvent, Option[TradeCommand]] {

--- a/modules/feed/src/main/scala/trading/feed/Main.scala
+++ b/modules/feed/src/main/scala/trading/feed/Main.scala
@@ -28,6 +28,6 @@ object Main extends IOApp.Simple:
       trTopic = AppTopic.TradingCommands.make(config.pulsar)
       fcTopic = AppTopic.ForecastCommands.make(config.pulsar)
       trading     <- Producer.sharded[IO, TradeCommand](pulsar, trTopic)
-      forecasting <- Producer.pulsar[IO, ForecastCommand](pulsar, fcTopic)
+      forecasting <- Producer.dedup[IO, ForecastCommand](pulsar, fcTopic)
       server = Ember.default[IO](config.httpPort)
     yield server -> Feed.random(trading, forecasting)

--- a/modules/processor/src/main/scala/trading/processor/Engine.scala
+++ b/modules/processor/src/main/scala/trading/processor/Engine.scala
@@ -1,12 +1,11 @@
 package trading.processor
 
 import trading.commands.TradeCommand
-import trading.core.{ Conflicts, TradeEngine }
-import trading.core.dedup.DedupRegistry
+import trading.core.TradeEngine
 import trading.domain.EventId
 import trading.events.TradeEvent
 import trading.lib.*
-import trading.state.{ DedupState, TradeState }
+import trading.state.TradeState
 
 import cats.MonadThrow
 import cats.syntax.all.*
@@ -14,24 +13,14 @@ import cats.syntax.all.*
 object Engine:
   def fsm[F[_]: GenUUID: Logger: MonadThrow: Time](
       producer: Producer[F, TradeEvent],
-      registry: DedupRegistry[F],
       ack: Consumer.MsgId => F[Unit]
-  ): FSM[F, (TradeState, DedupState), Consumer.Msg[TradeCommand], Unit] =
-    FSM { case ((st, ds), Consumer.Msg(msgId, _, command)) =>
-      Conflicts.dedup(ds)(command) match
-        case None =>
-          for
-            _ <- Logger[F].warn(s"Deduplicated Command ID: ${command.id.show}")
-            _ <- ack(msgId)
-          yield (st -> ds) -> ()
-        case Some(cmd) =>
-          val (nst, event) = TradeEngine.fsm.run(st, cmd)
-          for
-            evt <- (GenUUID[F].make[EventId], Time[F].timestamp).mapN(event)
-            ecs = TradeEvent._Command.get(evt).toList
-            nds <- Time[F].timestamp.map(Conflicts.updateMany(ds)(ecs, _))
-            _   <- producer.send(evt)
-            _   <- registry.save(nds)
-            _ <- ack(msgId).attempt.void // don't care if this fails (de-dup)
-          yield (nst -> nds) -> ()
+  ): FSM[F, TradeState, Consumer.Msg[TradeCommand], Unit] =
+    FSM { case (st, Consumer.Msg(msgId, _, cmd)) =>
+      val (nst, event) = TradeEngine.fsm.run(st, cmd)
+      for
+        evt <- (GenUUID[F].make[EventId], Time[F].timestamp).mapN(event)
+        ecs = TradeEvent._Command.get(evt).toList
+        _ <- producer.send(evt)
+        _ <- ack(msgId).attempt.void // don't care if this fails (de-dup)
+      yield nst -> ()
     }

--- a/modules/processor/src/main/scala/trading/processor/Main.scala
+++ b/modules/processor/src/main/scala/trading/processor/Main.scala
@@ -2,12 +2,11 @@ package trading.processor
 
 import trading.commands.TradeCommand
 import trading.core.AppTopic
-import trading.core.dedup.DedupRegistry
 import trading.core.http.Ember
 import trading.core.snapshots.SnapshotReader
 import trading.events.TradeEvent
 import trading.lib.{ given, * }
-import trading.state.{ DedupState, TradeState }
+import trading.state.TradeState
 
 import cats.effect.*
 import cats.syntax.apply.*
@@ -18,15 +17,14 @@ object Main extends IOApp.Simple:
   def run: IO[Unit] =
     Stream
       .resource(resources)
-      .flatMap { (server, consumer, snapshots, registry, fsm) =>
+      .flatMap { (server, consumer, snapshots, fsm) =>
         Stream.eval(server.useForever).concurrently {
-          Stream.eval((snapshots.latest, registry.get).tupled).flatMap {
-            case (Some(sn, id), dp) =>
-              val log = Logger[IO].debug(s"ID: $id - SNAPSHOTS: $sn") *> Logger[IO].debug(s"DEDUP: $dp")
-              Stream.eval(log) ++ consumer.receiveM(id).evalMapAccumulate(sn -> dp)(fsm.run)
-            case (None, dp) =>
-              Stream.exec(Logger[IO].debug(s"DEDUP: $dp")) ++
-                consumer.receiveM.evalMapAccumulate(TradeState.empty -> dp)(fsm.run)
+          Stream.eval(snapshots.latest).flatMap {
+            case Some(sn, id) =>
+              val log = Logger[IO].debug(s"ID: $id - SNAPSHOTS: $sn")
+              Stream.eval(log) ++ consumer.receiveM(id).evalMapAccumulate(sn)(fsm.run)
+            case None =>
+              consumer.receiveM.evalMapAccumulate(TradeState.empty)(fsm.run)
           }
         }
       }
@@ -47,8 +45,7 @@ object Main extends IOApp.Simple:
       server   = Ember.default[IO](config.httpPort)
       cmdTopic = AppTopic.TradingCommands.make(config.pulsar)
       evtTopic = AppTopic.TradingEvents.make(config.pulsar)
-      producer  <- Producer.pulsar[IO, TradeEvent](pulsar, evtTopic)
-      registry  <- DedupRegistry.make[IO](config.redisUri, config.appId, config.keyExpiration)
+      producer  <- Producer.dedup[IO, TradeEvent](pulsar, evtTopic)
       snapshots <- SnapshotReader.make[IO](config.redisUri)
       consumer  <- Consumer.pulsar[IO, TradeCommand](pulsar, cmdTopic, sub)
-    yield (server, consumer, snapshots, registry, Engine.fsm(producer, registry, consumer.ack))
+    yield (server, consumer, snapshots, Engine.fsm(producer, consumer.ack))

--- a/modules/processor/src/test/scala/trading/processor/EngineSuite.scala
+++ b/modules/processor/src/test/scala/trading/processor/EngineSuite.scala
@@ -4,7 +4,6 @@ import java.time.Instant
 import java.util.UUID
 
 import trading.commands.TradeCommand
-import trading.core.dedup.DedupRegistry
 import trading.domain.TradingStatus.*
 import trading.domain.*
 import trading.events.TradeEvent
@@ -34,28 +33,22 @@ object EngineSuite extends SimpleIOSuite with Checkers:
   given Time[IO] with
     def timestamp: IO[Timestamp] = IO.pure(ts)
 
-  val registry: DedupRegistry[IO] = new:
-    def get: IO[DedupState]               = IO.pure(DedupState.empty)
-    def save(state: DedupState): IO[Unit] = IO.unit
-
   test("Processor engine fsm") {
     for
       evts <- IO.ref(none[TradeEvent])
       acks <- IO.ref(none[Consumer.MsgId])
       prod = Producer.test(evts)
-      fsm  = Engine.fsm(prod, registry, i => acks.set(i.some))
-      (tst1, dst1) <- fsm.runS(
-        TradeState.empty -> DedupState.empty,
+      fsm  = Engine.fsm(prod, i => acks.set(i.some))
+      tst1 <- fsm.runS(
+        TradeState.empty,
         Consumer.Msg("id1", Map.empty, TradeCommand.Create(id, cid, s, TradeAction.Ask, p1, q1, "test", ts))
       )
       e1 <- evts.get
       a1 <- acks.get
       tex1 = TradeState(On, Map(s -> Prices(ask = Map(p1 -> q1), bid = Map.empty, p1, p1)))
-      dex1 = DedupState(Set(IdRegistry(id, ts)))
       res1 = NonEmptyList
         .of(
           expect.same(tst1, tex1),
-          expect.same(dst1, dex1),
           expect.same(e1.size, 1),
           expect.same(a1.size, 1)
         )

--- a/modules/snapshots/src/main/scala/trading/snapshots/Engine.scala
+++ b/modules/snapshots/src/main/scala/trading/snapshots/Engine.scala
@@ -32,9 +32,9 @@ object Engine:
           .attempt
           .flatMap {
             case Left(e) =>
-              Logger[F].warn(s"Failed to persist state for event ID: $lastId").tupleLeft(st -> ids)
+              Logger[F].warn(s"Failed to persist state: $lastId").tupleLeft(st -> ids)
             case Right(_) =>
-              Logger[F].debug(s"State persisted for event ID: $lastId") *>
+              Logger[F].debug(s"State persisted: $lastId. Acking ${ids.size} messages.") *>
                 acker.ack(ids.toSet).attempt.map {
                   case Left(_)  => (st -> ids)        -> ()
                   case Right(_) => (st -> List.empty) -> ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val monocle       = "3.1.0"
     val natchez       = "0.1.6"
     val natchezHttp4s = "0.3.2"
-    val neutron       = "0.3.0+19-d348109a-SNAPSHOT"
+    val neutron       = "0.3.0+27-9a903f0f-SNAPSHOT"
     val odin          = "0.13.0"
     val redis4cats    = "1.1.1"
     val refined       = "0.9.28"


### PR DESCRIPTION
Pulsar supports [deduplication](https://pulsar.apache.org/docs/en/cookbooks-deduplication/) since 2.7.0, which simplifies a lot of code. 

All the deduplication machinery is no longer needed (`DedupState`, `DedupRegistry` and `Conflicts`) but it's intentionally left in the code to showcase how such an implementation would look like.