### PR TITLE
alerts: change subscription to failover

### DIFF
--- a/modules/alerts/src/main/scala/trading/alerts/Main.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Main.scala
@@ -31,11 +31,12 @@ object Main extends IOApp.Simple:
       .compile
       .drain
 
-  // sharded by symbol (see Shard[TradeEvent] instance)
+  // Even though events are sharded by symbol or status, using KeyShared in alerts can be
+  // problematic when an instance goes does, due to consumers rebalance.
   val sub =
     Subscription.Builder
       .withName("alerts")
-      .withType(Subscription.Type.KeyShared)
+      .withType(Subscription.Type.Failover)
       .build
 
   // Alert producer settings, dedup and partitioned (for topic compaction in WS)

--- a/modules/alerts/src/main/scala/trading/alerts/Main.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Main.scala
@@ -19,12 +19,11 @@ object Main extends IOApp.Simple:
       .resource(resources)
       .flatMap { (server, consumer, snapshots, fsm) =>
         Stream.eval(server.useForever).concurrently {
-          val st = TradeState.empty
-          Stream.eval(snapshots.getLastId).flatMap {
-            case Some(id) =>
+          Stream.eval(snapshots.latest).flatMap {
+            case Some(st, id) =>
               consumer.receiveM(id).evalMapAccumulate(st)(fsm.run)
             case None =>
-              consumer.receiveM.evalMapAccumulate(st)(fsm.run)
+              consumer.receiveM.evalMapAccumulate(TradeState.empty)(fsm.run)
           }
         }
       }


### PR DESCRIPTION
After much thought, I've decided a `KeyShared` subscription is only problematic in stateful services (see the switch trick in `processor` to address this). Although it offers a much better throughput, due to many instances processing different events that can be sharded by `Symbol` or `TradingStatus`, when consumers are rebalanced (due to the number of instances changing), they won't have the correct aggregation for a specific symbol.

A potential solution could be to use [sticky consistent hashes](https://medium.com/@ankushkhanna1988/apache-pulsar-key-shared-mode-sticky-consistent-hashing-a4ee7133930a), but this can cause downtime when a single instance goes down (even during rollout), so it's less than ideal.

In the book, I'll discuss in details other possible solutions in case we have the need to scale the `alerts` service, but we can away with a `Failover` subscription for now.