### PR TITLE
feature: trading smoke tests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -61,9 +61,9 @@ jobs:
 
       - name: "Push trading Docker images 🐳"
         run: |
-          docker push ghcr.io/gvolpe/trading-alerts:latest
-          docker push ghcr.io/gvolpe/trading-processor:latest
-          docker push ghcr.io/gvolpe/trading-ws:latest
+          docker push trading-alerts:latest
+          docker push trading-processor:latest
+          docker push trading-ws:latest
 
       - name: "Shutting down Redis 🐳"
         run: docker-compose down

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -44,5 +44,26 @@ jobs:
       - name: "Run trading tests 🚀"
         run: nix develop -c sbt 'test;it/test;webapp/fastOptJS'
 
+      # ---- Build and push Docker images ----
+
+      - name: "Login to GitHub Container Registry "
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Build `jdk17-curl` Docker image 🚀"
+        run: docker build -t jdk17-curl modules/
+
+      - name: "Build Docker images 🚀"
+        run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws/docker:publishLocal'
+
+      - name: "Push trading Docker images 🐳"
+        run: |
+          docker push ghcr.io/gvolpe/trading-alerts:latest
+          docker push ghcr.io/gvolpe/trading-processor:latest
+          docker push ghcr.io/gvolpe/trading-ws:latest
+
       - name: "Shutting down Redis 🐳"
         run: docker-compose down

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -53,17 +53,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Build `jdk17-curl` Docker image 🚀"
+      - name: "Build jdk17-curl Docker image 🚀"
         run: docker build -t jdk17-curl modules/
 
-      - name: "Build Docker images 🚀"
+      - name: "Build trading Docker images 🚀"
         run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws/docker:publishLocal'
 
       - name: "Push trading Docker images 🐳"
         run: |
-          docker push trading-alerts:latest
-          docker push trading-processor:latest
-          docker push trading-ws:latest
+          docker images
+          docker tag trading-alerts ghcr.io/gvolpe/trading-alerts:latest
+          docker tag trading-processor ghcr.io/gvolpe/trading-processor:latest
+          docker tag trading-ws ghcr.io/gvolpe/trading-ws:latest
+          docker images
+          docker push ghcr.io/gvolpe/trading-alerts:latest
+          docker push ghcr.io/gvolpe/trading-processor:latest
+          docker push ghcr.io/gvolpe/trading-ws:latest
 
       - name: "Shutting down Redis 🐳"
         run: docker-compose down

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -61,11 +61,9 @@ jobs:
 
       - name: "Push trading Docker images 🐳"
         run: |
-          docker images
           docker tag trading-alerts ghcr.io/gvolpe/trading-alerts:latest
           docker tag trading-processor ghcr.io/gvolpe/trading-processor:latest
           docker tag trading-ws ghcr.io/gvolpe/trading-ws:latest
-          docker images
           docker push ghcr.io/gvolpe/trading-alerts:latest
           docker push ghcr.io/gvolpe/trading-processor:latest
           docker push ghcr.io/gvolpe/trading-ws:latest

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -3,8 +3,7 @@ name: Smokey
 on:
   workflow_run:
     workflows: ["Scala"]
-    pull_request:
-      branches: [main]
+    branches: [main]
     types:
       - completed
 
@@ -35,11 +34,9 @@ jobs:
           docker pull ghcr.io/gvolpe/trading-alerts:latest
           docker pull ghcr.io/gvolpe/trading-processor:latest
           docker pull ghcr.io/gvolpe/trading-ws:latest
-          docker images
           docker tag ghcr.io/gvolpe/trading-alerts trading-alerts:latest
           docker tag ghcr.io/gvolpe/trading-processor trading-processor:latest
           docker tag ghcr.io/gvolpe/trading-ws trading-ws:latest
-          docker images
 
       - name: "Starting up trading core services 🐳"
         run: docker-compose up -d processor alerts ws-server

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -3,7 +3,8 @@ name: Smokey
 on:
   workflow_run:
     workflows: ["Scala"]
-    branches: [main]
+    pull_request:
+      branches: [main]
     types:
       - completed
 

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -41,6 +41,9 @@ jobs:
           name: feda
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - name: "Build `jdk17-curl` Docker image 🚀"
+        run: docker build -t jdk17-curl modules/
+
       - name: "Build Docker images 🚀"
         run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws-server/docker:publishLocal'
 

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -1,23 +1,11 @@
 name: Smokey
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'web-app/**'
-      - 'imgs/**'
-      - 'README.md'
-      - 'kafka.yml'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'web-app/**'
-      - 'imgs/**'
-      - 'README.md'
-      - 'docker-compose.yml'
-      - 'kafka.yml'
+  workflow_run:
+    workflows: ["Scala"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build:
@@ -41,11 +29,16 @@ jobs:
           name: feda
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: "Build `jdk17-curl` Docker image 🚀"
-        run: docker build -t jdk17-curl modules/
-
-      - name: "Build Docker images 🚀"
-        run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws/docker:publishLocal'
+      - name: "Pull Docker images from registry 🐳"
+        run: |
+          docker pull ghcr.io/gvolpe/trading-alerts:latest
+          docker pull ghcr.io/gvolpe/trading-processor:latest
+          docker pull ghcr.io/gvolpe/trading-ws:latest
+          docker images
+          docker tag ghcr.io/gvolpe/trading-alerts trading-alerts:latest
+          docker tag ghcr.io/gvolpe/trading-processor trading-processor:latest
+          docker tag ghcr.io/gvolpe/trading-ws trading-ws:latest
+          docker images
 
       - name: "Starting up trading core services 🐳"
         run: docker-compose up -d processor alerts ws-server

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -45,7 +45,7 @@ jobs:
         run: docker build -t jdk17-curl modules/
 
       - name: "Build Docker images 🚀"
-        run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws-server/docker:publishLocal'
+        run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws/docker:publishLocal'
 
       - name: "Starting up trading core services 🐳"
         run: docker-compose up -d processor alerts ws-server

--- a/.github/workflows/ci-smokey.yml
+++ b/.github/workflows/ci-smokey.yml
@@ -1,0 +1,54 @@
+name: Smokey
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'web-app/**'
+      - 'imgs/**'
+      - 'README.md'
+      - 'kafka.yml'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'web-app/**'
+      - 'imgs/**'
+      - 'README.md'
+      - 'docker-compose.yml'
+      - 'kafka.yml'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2.3.2
+
+      - name: "Cache for sbt & coursier ♨️"
+        uses: coursier/cache-action@v4.1
+
+      - name: "Starting up Pulsar & Redis 🐳"
+        run: docker-compose up -d pulsar redis
+
+      - name: "Install Nix ❄️"
+        uses: cachix/install-nix-action@v16
+
+      - name: "Install Cachix ❄️"
+        uses: cachix/cachix-action@v10
+        with:
+          name: feda
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: "Build Docker images 🚀"
+        run: nix develop -c sbt 'processor/docker:publishLocal;alerts/docker:publishLocal;ws-server/docker:publishLocal'
+
+      - name: "Starting up trading core services 🐳"
+        run: docker-compose up -d processor alerts ws-server
+
+      - name: "Run smokey tests 🚀"
+        run: nix develop -c sbt 'smokey/test'
+
+      - name: "Shutting down containers 🐳"
+        run: docker-compose down

--- a/README.md
+++ b/README.md
@@ -200,8 +200,31 @@ All unit tests can be executed via `sbt test`. There's also a small suite of int
 
 It contains all the standalone examples shown in the book. It also showcases both `KafkaDemo` and `MemDemo` programs that use the same `Consumer` and `Producer` abstractions defined in the `lib` module.
 
+### X QA
+
+It contains the `smokey` project that models the smoke test for trading.
+
 ## Monitoring
 
 JVM stats are provided for every service via Prometheus and Grafana.
 
 ![grafana](./imgs/grafana.png)
+
+## Topic compaction
+
+Two Pulsar topics can be compacted to speed-up reads on startup, corresponding to `Alert` and `TradeEvent.Switch`.
+
+To compact a topic on demand (useful for manual testing), run these commands.
+
+```console
+$ docker-compose exec pulsar bin/pulsar-admin topics compact persistent://public/default/trading-alerts
+Topic compaction requested for persistent://public/default/trading-alerts.
+$ docker-compose exec pulsar bin/pulsar-admin topics compact persistent://public/default/trading-switch-events
+Topic compaction requested for persistent://public/default/trading-switch-events
+```
+
+In production, one would configure topic compaction to be triggered automatically at the namespace level when certain threshold is reached. For example, to trigger compaction when the backlog reaches 10MB:
+
+```console
+$ docker-compose exec pulsar bin/pulsar-admin namespaces set-compaction-threshold --threshold 10M public/default
+```

--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,16 @@ lazy val it = (project in file("modules/it"))
   .dependsOn(domain.jvm % "compile->compile;compile->test")
   .dependsOn(forecasts)
 
+// extension qa smoke tests
+lazy val smokey = (project in file("modules/x-qa"))
+  .settings(commonSettings: _*)
+  .dependsOn(core, domain.jvm)
+  .settings(
+    libraryDependencies ++= List(
+      Libraries.http4sJdkWs
+    )
+  )
+
 // extension demo
 lazy val demo = (project in file("modules/x-demo"))
   .settings(commonSettings: _*)

--- a/modules/domain/shared/src/main/scala/trading/domain/Symbol.scala
+++ b/modules/domain/shared/src/main/scala/trading/domain/Symbol.scala
@@ -10,5 +10,8 @@ type Symbol = Symbol.Type
 object Symbol extends RefNewtype[String, NonEmptyFiniteString[6]]:
   // Note: unsafeFrom should not be needed once Refined macros work in Scala 3
   val CHFEUR = unsafeFrom("CHFEUR")
+  val EURPLN = unsafeFrom("EURPLN")
   val EURUSD = unsafeFrom("EURUSD")
+  val GBPUSD = unsafeFrom("GBPUSD")
+  val USDCAD = unsafeFrom("USDCAD")
   val XXXXXX = unsafeFrom("XXXXXX")

--- a/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
@@ -52,8 +52,7 @@ object TradeEvent:
       case e: Stopped => Switch(e.asRight).some
       case _          => none
 
-    given Eq[Switch] = new:
-      def eqv(x: Switch, y: Switch): Boolean = x.getEvent === y.getEvent
+    given Eq[Switch] = Eq.by(_.getEvent)
 
   // EventId and Timestamp are regenerated when reprocessed so we don't consider them for deduplication.
   given Eq[TradeEvent] = Eq.and(Eq.by(_.cid), Eq.by(_Command.get))

--- a/modules/domain/shared/src/main/scala/trading/ws/WsOut.scala
+++ b/modules/domain/shared/src/main/scala/trading/ws/WsOut.scala
@@ -2,7 +2,8 @@ package trading.ws
 
 import trading.domain.*
 
-import cats.Show
+import cats.{ Eq, Show }
+import cats.syntax.eq.*
 import io.circe.Codec
 
 enum WsOut derives Codec.AsObject:
@@ -12,3 +13,9 @@ enum WsOut derives Codec.AsObject:
 object WsOut:
   // typeclass derivation does not work
   given Show[WsOut] = Show.fromToString
+
+  given Eq[WsOut] = Eq.instance {
+    case (x: Attached, y: Attached)         => x == y  // universal eq
+    case (Notification(x), Notification(y)) => x === y // Eq[Alert] instance
+    case _                                  => false
+  }

--- a/modules/ws-server/src/main/scala/trading/ws/Main.scala
+++ b/modules/ws-server/src/main/scala/trading/ws/Main.scala
@@ -9,6 +9,7 @@ import cats.effect.*
 import cats.syntax.all.*
 import dev.profunktor.pulsar.{ Consumer as PulsarConsumer, Pulsar, Subscription }
 import fs2.Stream
+import org.apache.pulsar.client.api.SubscriptionInitialPosition
 
 object Main extends IOApp.Simple:
   def run: IO[Unit] =
@@ -32,9 +33,13 @@ object Main extends IOApp.Simple:
       .withType(Subscription.Type.Exclusive)
       .build
 
-  // Alert consumer settings (for topic compaction)
+  // Alert consumer settings (topic compaction & previous reads)
   val compact =
-    PulsarConsumer.Settings[IO, Alert]().withReadCompacted.some
+    PulsarConsumer
+      .Settings[IO, Alert]()
+      .withInitialPosition(SubscriptionInitialPosition.Earliest)
+      .withReadCompacted
+      .some
 
   def resources =
     for

--- a/modules/x-qa/smoke-tests.md
+++ b/modules/x-qa/smoke-tests.md
@@ -1,0 +1,39 @@
+# smokey
+
+1. Run the essential applications via `docker-compose`.
+2. Connect via WS and subscribe to a subset of symbols.
+3. Generate and publish a fixed set of `TradeCommand`s.
+4. Verify the WS client gets the expected alerts.
+
+## Run smoke tests locally
+
+Run the essential trading services from scratch.
+
+```console
+$ dc up pulsar redis processor alerts ws-server
+```
+
+Run the smoke tests.
+
+```console
+$ sbt smokey/test
+```
+
+### Helpers
+
+A few commands that might help clearing the internal state if something goes wrong (otherwise, tearing all the containers down and restarting them up again should do).
+
+Delete both the `trading-alerts` and the `trading-switch-events` topics.
+
+```console
+$ docker-compose exec pulsar bin/pulsar-admin topics delete persistent://public/default/trading-alerts
+$ docker-compose exec pulsar bin/pulsar-admin topics delete persistent://public/default/trading-switch-events
+```
+
+For these commands to succeed, there should be no active producers / consumers for these topics.
+
+Clear Redis state.
+
+```console
+docker-compose exec redis redis-cli FLUSHALL
+```

--- a/modules/x-qa/src/test/scala/smokey/Smokey.scala
+++ b/modules/x-qa/src/test/scala/smokey/Smokey.scala
@@ -1,0 +1,128 @@
+package smokey
+
+import java.time.Instant
+import java.util.UUID
+
+import scala.concurrent.duration.*
+
+import trading.commands.TradeCommand
+import trading.commands.TradeCommand.*
+import trading.core.AppTopic
+import trading.domain.*
+import trading.domain.Symbol.*
+import trading.lib.{ Producer, Shard }
+import trading.ws.*
+
+import cats.effect.*
+import cats.syntax.all.*
+import dev.profunktor.pulsar.{ Config, Producer as PulsarProducer, Pulsar, SeqIdMaker }
+import fs2.Stream
+import io.circe.parser.decode as jsonDecode
+import io.circe.syntax.*
+import org.http4s.client.websocket.{ WSClient, WSDataFrame, WSFrame, WSRequest }
+import org.http4s.implicits.*
+import org.http4s.jdkhttpclient.JdkWSClient
+import weaver.{ Expectations, IOSuite }
+
+object Smokey extends IOSuite:
+  type Res = (Pulsar.T, WSClient[IO])
+
+  val pulsarCfg  = Config.Builder.default
+  val connectReq = WSRequest(uri"ws://localhost:9000/v1/ws")
+
+  override def sharedResource: Resource[IO, Res] =
+    (Pulsar.make[IO](pulsarCfg.url), JdkWSClient.simple[IO]).tupled
+
+  val symbols1: List[WsIn] = List(EURUSD, USDCAD, GBPUSD).map(WsIn.Subscribe(_))
+  val symbols2: List[WsIn] = List(EURPLN, CHFEUR).map(WsIn.Subscribe(_))
+
+  def mkId  = CommandId(UUID.randomUUID)
+  def mkCid = CorrelationId(UUID.randomUUID)
+  val mkTs  = Timestamp(Instant.now)
+
+  val commands: List[TradeCommand] = List(
+    Create(mkId, mkCid, EURUSD, TradeAction.Ask, Price(4.5), Quantity(10), "test", mkTs),
+    Create(mkId, mkCid, CHFEUR, TradeAction.Ask, Price(2.3), Quantity(55), "test", mkTs),
+    Create(mkId, mkCid, USDCAD, TradeAction.Bid, Price(3.7), Quantity(7), "test", mkTs),
+    Create(mkId, mkCid, GBPUSD, TradeAction.Bid, Price(2.6), Quantity(89), "test", mkTs),
+    Update(mkId, mkCid, GBPUSD, TradeAction.Bid, Price(2.8), Quantity(24), "test", mkTs)
+  )
+
+  val aid = AlertId(UUID.randomUUID)
+  val cid = mkCid
+
+  // See Eq[TradeAlert]: AlertId, CorrelationId and Timestamp are not used for equality.
+  val expected: List[WsOut] = List(
+    Alert.TradeAlert(aid, cid, AlertType.Neutral, Symbol.EURUSD, Price(4.5), Price(0), Price(4.5), Price(4.5), mkTs),
+    Alert.TradeAlert(aid, cid, AlertType.StrongSell, Symbol.USDCAD, Price(0), Price(3.7), Price(3.7), Price(3.7), mkTs)
+  ).map(_.wsOut)
+
+  def encode(wsIn: WsIn): WSDataFrame =
+    WSFrame.Text(wsIn.asJson.noSpaces)
+
+  val tcSettings =
+    PulsarProducer
+      .Settings[IO, TradeCommand]()
+      .withDeduplication(SeqIdMaker.fromEq)
+      .withShardKey(Shard[TradeCommand].key)
+      .some
+
+  val topic = AppTopic.TradingCommands.make(pulsarCfg)
+
+  def p1(pulsar: Pulsar.T): IO[Unit] =
+    Producer.pulsar[IO, TradeCommand](pulsar, topic, tcSettings).use { p =>
+      IO.sleep(2.seconds) *>
+        Stream.emits(commands).metered[IO](100.millis).evalMap(p.send).compile.drain
+    }
+
+  // TODO: Next we could add a second WSClient subscribing to symbols2
+  def p2(client: WSClient[IO]): IO[List[WsOut]] =
+    (IO.ref(List.empty[WsOut]), IO.deferred[Either[Throwable, Unit]]).tupled.flatMap { (ref, switch) =>
+      client
+        .connectHighLevel(connectReq)
+        .use { ws =>
+          val recv =
+            ws.receiveStream
+              .evalMap {
+                case WSFrame.Text(str, _) =>
+                  jsonDecode[WsOut](str) match
+                    case Right(out) => IO.println(s"<<< $out") *> ref.update(_ :+ out)
+                    case Left(err)  => IO.println(s"Fail to decode WsOut: $err")
+                case WSFrame.Binary(_, _) =>
+                  IO.unit
+              }
+              .evalMapAccumulate(1) { (acc, _) =>
+                switch.complete(().asRight).whenA(acc == 3).tupleLeft(acc + 1)
+              }
+
+          val heartbeats =
+            Stream.eval(ws.send(encode(WsIn.Heartbeat))).metered[IO](5.seconds)
+
+          val send =
+            Stream.emits(symbols1).evalMap { s =>
+              ws.send(encode(s))
+            }
+
+          Stream(heartbeats, recv, send)
+            .parJoin(3)
+            .interruptWhen(switch)
+            .compile
+            .drain
+        }
+        .handleErrorWith { e =>
+          IO.println(s"<<< WS conn error: ${e.getMessage}")
+        } *> ref.get
+    }
+
+  test("Trading smoke test") { case (pulsar, ws) =>
+    (p1(pulsar) &> p2(ws))
+      .flatMap {
+        case ((x: WsOut.Attached) :: xs) =>
+          IO.pure(expect.same(xs, expected))
+        case xs =>
+          for
+            _ <- IO.println("\n--- WsOut list ---\n")
+            _ <- xs.traverse_(IO.println)
+          yield failure("Expected 3 messages")
+      }
+  }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
     val fs2Core       = "3.2.7"
     val fs2Kafka      = "2.4.0"
     val http4s        = "1.0.0-M32"
+    val http4sWs      = "1.0.0-M1"
     val kittens       = "3.0.0-M1"
     val monocle       = "3.1.0"
     val natchez       = "0.1.6"
@@ -57,6 +58,8 @@ object Dependencies {
     val http4sClient  = http4s("ember-client")
     val http4sCirce   = http4s("circe")
     val http4sMetrics = http4s("prometheus-metrics")
+
+    val http4sJdkWs = "org.http4s" %% "http4s-jdk-http-client" % V.http4sWs
 
     val natchezCore      = "org.tpolecat" %% "natchez-core"      % V.natchez
     val natchezHoneycomb = "org.tpolecat" %% "natchez-honeycomb" % V.natchez


### PR DESCRIPTION
Initial implementation of smoke tests for the basic trading functionality. It also includes a lot of CI work.

On every build, Docker images of the core trading services are published into the Github Container Registry after all the unit and integration tests pass.

When a PR is merged into `main`, it should trigger the smoke-tests workflow, which would pull the latest Docker images from the registry to do so. 

This emulates a typical workflow used in real-world applications, which would run smoke tests from the `main` branch before it is promoted into a QA or Staging environment.