### PR TITLE
split switch commands and events from trading

### DIFF
--- a/modules/alerts/src/main/scala/trading/alerts/Engine.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Engine.scala
@@ -6,7 +6,7 @@ import trading.domain.Alert.{ TradeAlert, TradeUpdate }
 import trading.domain.AlertType.*
 import trading.domain.TradingStatus.*
 import trading.domain.*
-import trading.events.TradeEvent
+import trading.events.*
 import trading.lib.*
 import trading.lib.Consumer.{ Msg, MsgId }
 import trading.state.TradeState
@@ -15,59 +15,63 @@ import cats.MonadThrow
 import cats.syntax.all.*
 
 object Engine:
+  type In = Either[Msg[TradeEvent], Msg[SwitchEvent]]
+
   def fsm[F[_]: GenUUID: Logger: MonadThrow: Time](
       producer: Producer[F, Alert],
-      ack: Consumer.MsgId => F[Unit]
-  ): FSM[F, TradeState, Consumer.Msg[TradeEvent], Unit] =
+      tradeAcker: Acker[F, TradeEvent],
+      switchAcker: Acker[F, SwitchEvent]
+  ): FSM[F, TradeState, In, Unit] =
     def mkIdTs: F[(AlertId, Timestamp)] =
       (GenUUID[F].make[AlertId], Time[F].timestamp).tupled
 
-    def sendAck(alert: Alert, msgId: MsgId): F[Unit] =
-      (producer.send(alert) *> ack(msgId)).attempt.void
+    def sendAck(alert: Alert, ack: F[Unit]): F[Unit] =
+      (producer.send(alert) *> ack).attempt.void
 
     FSM {
-      // if the same event was previously sent by other instance, Pulsar will deduplicate it
-      // also, no need to keep track of TradingStatus in this FSM, so we don't flip the switch
-      case (st, Msg(msgId, _, TradeEvent.Started(_, cid, _))) =>
-        mkIdTs.map(TradeUpdate(_, cid, On, _)).flatMap { alert =>
-          sendAck(alert, msgId).tupleLeft(st)
+      // switch events
+      case (st, Right(Msg(msgId, _, SwitchEvent.Started(_, cid, _)))) =>
+        val nst = TradeState._Status.replace(On)(st)
+        mkIdTs.map(TradeUpdate(_, cid, nst.status, _)).flatMap { alert =>
+          sendAck(alert, switchAcker.ack(msgId)).tupleLeft(nst)
         }
-      case (st, Msg(msgId, _, TradeEvent.Stopped(_, cid, _))) =>
-        mkIdTs.map(TradeUpdate(_, cid, Off, _)).flatMap { alert =>
-          sendAck(alert, msgId).tupleLeft(st)
+      case (st, Right(Msg(msgId, _, SwitchEvent.Stopped(_, cid, _)))) =>
+        val nst = TradeState._Status.replace(Off)(st)
+        mkIdTs.map(TradeUpdate(_, cid, nst.status, _)).flatMap { alert =>
+          sendAck(alert, switchAcker.ack(msgId)).tupleLeft(nst)
         }
       // no alert emitted, just ack the message
-      case (st, Msg(msgId, _, TradeEvent.CommandRejected(_, _, _, _, _))) =>
-        ack(msgId).tupleLeft(st)
+      case (st, Right(Msg(msgId, _, SwitchEvent.Ignored(_, _, _)))) =>
+        switchAcker.ack(msgId).tupleLeft(st)
+      case (st, Left(Msg(msgId, _, TradeEvent.CommandRejected(_, _, _, _, _)))) =>
+        tradeAcker.ack(msgId).tupleLeft(st)
       // send price alert accordingly
-      case (st, Msg(msgId, _, TradeEvent.CommandExecuted(_, cid, cmd, _))) =>
-        TradeCommand._Symbol.get(cmd).fold(ack(msgId).attempt.void.tupleLeft(st)) { symbol =>
-          val nst = TradeEngine.fsm.runS(st, cmd)
-          val p   = st.prices.get(symbol)
-          val c   = nst.prices.get(symbol)
+      case (st, Left(Msg(msgId, _, TradeEvent.CommandExecuted(_, cid, cmd, _)))) =>
+        val nst = TradeEngine.fsm.runS(st, cmd)
+        val p   = st.prices.get(cmd.symbol)
+        val c   = nst.prices.get(cmd.symbol)
 
-          val previousAskMax: AskPrice = p.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
-          val previousBidMax: BidPrice = p.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
-          val currentAskMax: AskPrice  = c.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
-          val currentBidMax: BidPrice  = c.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
+        val previousAskMax: AskPrice = p.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
+        val previousBidMax: BidPrice = p.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
+        val currentAskMax: AskPrice  = c.flatMap(_.ask.keySet.maxOption).getOrElse(Price(0.0))
+        val currentBidMax: BidPrice  = c.flatMap(_.bid.keySet.maxOption).getOrElse(Price(0.0))
 
-          val high: Price = c.map(_.high).getOrElse(Price(0.0))
-          val low: Price  = c.map(_.low).getOrElse(Price(0.0))
+        val high: Price = c.map(_.high).getOrElse(Price(0.0))
+        val low: Price  = c.map(_.low).getOrElse(Price(0.0))
 
-          // dummy logic to simulate the trading market
-          def mkAlert(id: AlertId, ts: Timestamp): Alert =
-            if previousAskMax - currentAskMax > Price(0.3) then
-              TradeAlert(id, cid, StrongBuy, symbol, currentAskMax, currentBidMax, high, low, ts)
-            else if previousAskMax - currentAskMax > Price(0.2) then
-              TradeAlert(id, cid, Buy, symbol, currentAskMax, currentBidMax, high, low, ts)
-            else if currentBidMax - previousBidMax > Price(0.3) then
-              TradeAlert(id, cid, StrongSell, symbol, currentAskMax, currentBidMax, high, low, ts)
-            else if currentBidMax - previousBidMax > Price(0.2) then
-              TradeAlert(id, cid, Sell, symbol, currentAskMax, currentBidMax, high, low, ts)
-            else TradeAlert(id, cid, Neutral, symbol, currentAskMax, currentBidMax, high, low, ts)
+        // dummy logic to simulate the trading market
+        def mkAlert(id: AlertId, ts: Timestamp): Alert =
+          if previousAskMax - currentAskMax > Price(0.3) then
+            TradeAlert(id, cid, StrongBuy, cmd.symbol, currentAskMax, currentBidMax, high, low, ts)
+          else if previousAskMax - currentAskMax > Price(0.2) then
+            TradeAlert(id, cid, Buy, cmd.symbol, currentAskMax, currentBidMax, high, low, ts)
+          else if currentBidMax - previousBidMax > Price(0.3) then
+            TradeAlert(id, cid, StrongSell, cmd.symbol, currentAskMax, currentBidMax, high, low, ts)
+          else if currentBidMax - previousBidMax > Price(0.2) then
+            TradeAlert(id, cid, Sell, cmd.symbol, currentAskMax, currentBidMax, high, low, ts)
+          else TradeAlert(id, cid, Neutral, cmd.symbol, currentAskMax, currentBidMax, high, low, ts)
 
-          mkIdTs.map(mkAlert).flatMap { alert =>
-            sendAck(alert, msgId).tupleLeft(nst)
-          }
+        mkIdTs.map(mkAlert).flatMap { alert =>
+          sendAck(alert, tradeAcker.ack(msgId)).tupleLeft(nst)
         }
     }

--- a/modules/alerts/src/main/scala/trading/alerts/Main.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Main.scala
@@ -4,26 +4,32 @@ import trading.core.AppTopic
 import trading.core.http.Ember
 import trading.core.snapshots.SnapshotReader
 import trading.domain.Alert
-import trading.events.TradeEvent
+import trading.events.*
 import trading.lib.{ given, * }
 import trading.state.TradeState
 
 import cats.effect.*
 import cats.syntax.all.*
-import dev.profunktor.pulsar.{ Producer as PulsarProducer, Pulsar, SeqIdMaker, Subscription }
+import dev.profunktor.pulsar.{
+  Consumer as PulsarConsumer,
+  Producer as PulsarProducer,
+  Pulsar,
+  SeqIdMaker,
+  Subscription
+}
 import fs2.Stream
 
 object Main extends IOApp.Simple:
   def run: IO[Unit] =
     Stream
       .resource(resources)
-      .flatMap { (server, consumer, snapshots, fsm) =>
+      .flatMap { (server, trConsumer, swConsumer, snapshots, fsm) =>
         Stream.eval(server.useForever).concurrently {
           Stream.eval(snapshots.latest).flatMap {
             case Some(st, id) =>
-              consumer.receiveM(id).evalMapAccumulate(st)(fsm.run)
+              trConsumer.receiveM(id).either(swConsumer.receiveM).evalMapAccumulate(st)(fsm.run)
             case None =>
-              consumer.receiveM.evalMapAccumulate(TradeState.empty)(fsm.run)
+              trConsumer.receiveM.either(swConsumer.receiveM).evalMapAccumulate(TradeState.empty)(fsm.run)
           }
         }
       }
@@ -46,15 +52,21 @@ object Main extends IOApp.Simple:
       .withMessageKey(Partition[Alert].key)
       .some
 
+  val compact =
+    PulsarConsumer.Settings[IO, SwitchEvent]().withReadCompacted.some
+
   def resources =
     for
       config <- Resource.eval(Config.load[IO])
       pulsar <- Pulsar.make[IO](config.pulsar.url)
       _      <- Resource.eval(Logger[IO].info("Initializing alerts service"))
-      alertsTopic = AppTopic.Alerts.make(config.pulsar)
-      eventsTopic = AppTopic.TradingEvents.make(config.pulsar)
-      snapshots <- SnapshotReader.make[IO](config.redisUri)
-      producer  <- Producer.pulsar[IO, Alert](pulsar, alertsTopic, pSettings)
-      consumer  <- Consumer.pulsar[IO, TradeEvent](pulsar, eventsTopic, sub)
+      alertsTopic  = AppTopic.Alerts.make(config.pulsar)
+      switchTopic  = AppTopic.SwitchEvents.make(config.pulsar)
+      tradingTopic = AppTopic.TradingEvents.make(config.pulsar)
+      snapshots  <- SnapshotReader.make[IO](config.redisUri)
+      producer   <- Producer.pulsar[IO, Alert](pulsar, alertsTopic, pSettings)
+      trConsumer <- Consumer.pulsar[IO, TradeEvent](pulsar, tradingTopic, sub)
+      swConsumer <- Consumer.pulsar[IO, SwitchEvent](pulsar, switchTopic, sub, compact)
+      engine = Engine.fsm(producer, trConsumer, swConsumer)
       server = Ember.default[IO](config.httpPort)
-    yield (server, consumer, snapshots, Engine.fsm(producer, consumer.ack))
+    yield (server, trConsumer, swConsumer, snapshots, engine)

--- a/modules/core/src/main/scala/trading/core/AppTopic.scala
+++ b/modules/core/src/main/scala/trading/core/AppTopic.scala
@@ -13,14 +13,18 @@ object AppTopic:
 
   case object TradingCommands extends AppTopic:
     val name: String                    = "trading-commands"
-    def make(cfg: Config): Topic.Single = mkNonPersistent(cfg, name)
+    def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
+
+  case object SwitchCommands extends AppTopic:
+    val name: String                    = "switch-commands"
+    def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
 
   case object TradingEvents extends AppTopic:
     val name: String                    = "trading-events"
     def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
 
   case object SwitchEvents extends AppTopic:
-    val name: String                    = "trading-switch-events"
+    val name: String                    = "switch-events"
     def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
 
   case object ForecastCommands extends AppTopic:

--- a/modules/core/src/test/scala/trading/core/TradeEngineSuite.scala
+++ b/modules/core/src/test/scala/trading/core/TradeEngineSuite.scala
@@ -3,16 +3,16 @@ package trading.core
 import java.time.Instant
 import java.util.UUID
 
-import trading.commands.TradeCommand
+import trading.commands.*
 import trading.core.TradeEngine.fsm
 import trading.domain.TradingStatus.*
 import trading.domain.*
+import trading.events.*
 import trading.state.*
 
 import cats.data.NonEmptyList
 import weaver.FunSuite
 import weaver.scalacheck.Checkers
-import trading.events.TradeEvent
 
 object TradeEngineSuite extends FunSuite with Checkers:
   val id  = CommandId(UUID.randomUUID())
@@ -48,10 +48,10 @@ object TradeEngineSuite extends FunSuite with Checkers:
     val xst4       = TradeState(On, Map(s -> Prices(ask = Map(p2 -> q2), bid = Map(p1 -> q1), p2, p1)))
     val xev4       = TradeEvent.CommandExecuted(eid, cid, cmd4, ts)
 
-    val cmd5       = TradeCommand.Stop(id, cid, ts)
+    val cmd5       = SwitchCommand.Stop(id, cid, ts)
     val (st5, ev5) = fsm.run(st4, cmd5)
     val xst5       = TradeState(Off, xst4.prices)
-    val xev5       = TradeEvent.Stopped(eid, cid, ts)
+    val xev5       = SwitchEvent.Stopped(eid, cid, ts)
 
     val cmd6       = TradeCommand.Create(id, cid, s, TradeAction.Bid, p1, q1, "test", ts)
     val (st6, ev6) = fsm.run(st5, cmd6)

--- a/modules/domain/shared/src/main/scala/trading/commands/SwitchCommand.scala
+++ b/modules/domain/shared/src/main/scala/trading/commands/SwitchCommand.scala
@@ -1,0 +1,52 @@
+package trading.commands
+
+import trading.domain.{ given, * }
+
+// FIXME: importing all `given` yield ambiguous implicits
+import cats.derived.semiauto.{ coproductEq, product, productEq, * }
+import cats.syntax.all.*
+import cats.{ Applicative, Eq, Show }
+import io.circe.Codec
+import monocle.Traversal
+
+sealed trait SwitchCommand derives Codec.AsObject, Eq, Show:
+  def id: CommandId
+  def cid: CorrelationId
+  def createdAt: Timestamp
+
+object SwitchCommand:
+  final case class Start(
+      id: CommandId,
+      cid: CorrelationId,
+      createdAt: Timestamp
+  ) extends SwitchCommand
+
+  final case class Stop(
+      id: CommandId,
+      cid: CorrelationId,
+      createdAt: Timestamp
+  ) extends SwitchCommand
+
+  val _CommandId: Traversal[SwitchCommand, CommandId] = new:
+    def modifyA[F[_]: Applicative](f: CommandId => F[CommandId])(s: SwitchCommand): F[SwitchCommand] =
+      f(s.id).map { newId =>
+        s match
+          case c: Start  => c.copy(id = newId)
+          case c: Stop   => c.copy(id = newId)
+      }
+
+  val _CorrelationId: Traversal[SwitchCommand, CorrelationId] = new:
+    def modifyA[F[_]: Applicative](f: CorrelationId => F[CorrelationId])(s: SwitchCommand): F[SwitchCommand] =
+      f(s.cid).map { newCid =>
+        s match
+          case c: Start  => c.copy(cid = newCid)
+          case c: Stop   => c.copy(cid = newCid)
+      }
+
+  val _CreatedAt: Traversal[SwitchCommand, Timestamp] = new:
+    def modifyA[F[_]: Applicative](f: Timestamp => F[Timestamp])(s: SwitchCommand): F[SwitchCommand] =
+      f(s.createdAt).map { ts =>
+        s match
+          case c: Start  => c.copy(createdAt = ts)
+          case c: Stop   => c.copy(createdAt = ts)
+      }

--- a/modules/domain/shared/src/main/scala/trading/domain/AppId.scala
+++ b/modules/domain/shared/src/main/scala/trading/domain/AppId.scala
@@ -2,4 +2,10 @@ package trading.domain
 
 import java.util.UUID
 
+import cats.Show
+import cats.syntax.show.*
+
 case class AppId(name: String, id: UUID)
+
+object AppId:
+  given Show[AppId] = Show.show(x => s"${x.name}-${x.id.show}")

--- a/modules/domain/shared/src/main/scala/trading/events/SwitchEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/SwitchEvent.scala
@@ -1,0 +1,54 @@
+package trading.events
+
+import trading.commands.SwitchCommand
+import trading.domain.{ given, * }
+
+import cats.{ Applicative, Eq, Show }
+// FIXME: importing all `given` yield ambiguous implicits
+import cats.derived.semiauto.{ derived, product }
+import cats.syntax.all.*
+import io.circe.Codec
+import monocle.Traversal
+
+sealed trait SwitchEvent derives Codec.AsObject, Show:
+  def id: EventId
+  def cid: CorrelationId
+  def createdAt: Timestamp
+
+  // this is used to run the command via the trading fsm, only cid matters
+  def getCommand: Option[SwitchCommand] =
+    this match
+      case SwitchEvent.Started(id, cid, ts) => SwitchCommand.Start(CommandId(id.value), cid, ts).some
+      case SwitchEvent.Stopped(id, cid, ts) => SwitchCommand.Stop(CommandId(id.value), cid, ts).some
+      case SwitchEvent.Ignored(_, _, _)     => none
+
+object SwitchEvent:
+  final case class Started(
+      id: EventId,
+      cid: CorrelationId,
+      createdAt: Timestamp
+  ) extends SwitchEvent
+
+  final case class Stopped(
+      id: EventId,
+      cid: CorrelationId,
+      createdAt: Timestamp
+  ) extends SwitchEvent
+
+  final case class Ignored(
+      id: EventId,
+      cid: CorrelationId,
+      createdAt: Timestamp
+  ) extends SwitchEvent
+
+  // EventId and Timestamp are regenerated when reprocessed so we don't consider them for deduplication.
+  given Eq[SwitchEvent] = Eq.by(_.cid)
+
+  val _CorrelationId: Traversal[SwitchEvent, CorrelationId] = new:
+    def modifyA[F[_]: Applicative](f: CorrelationId => F[CorrelationId])(s: SwitchEvent): F[SwitchEvent] =
+      f(s.cid).map { newCid =>
+        s match
+          case c: Ignored => c.copy(cid = newCid)
+          case c: Started => c.copy(cid = newCid)
+          case c: Stopped => c.copy(cid = newCid)
+      }

--- a/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
@@ -8,11 +8,12 @@ import cats.{ Applicative, Eq, Show }
 import cats.derived.semiauto.{ derived, product }
 import cats.syntax.all.*
 import io.circe.Codec
-import monocle.{ Getter, Traversal }
+import monocle.Traversal
 
 sealed trait TradeEvent derives Codec.AsObject, Show:
   def id: EventId
   def cid: CorrelationId
+  def command: TradeCommand
   def createdAt: Timestamp
 
 object TradeEvent:
@@ -31,38 +32,8 @@ object TradeEvent:
       createdAt: Timestamp
   ) extends TradeEvent
 
-  final case class Started(
-      id: EventId,
-      cid: CorrelationId,
-      createdAt: Timestamp
-  ) extends TradeEvent
-
-  final case class Stopped(
-      id: EventId,
-      cid: CorrelationId,
-      createdAt: Timestamp
-  ) extends TradeEvent
-
-  final case class Switch(evt: Either[Started, Stopped]) derives Codec.AsObject, Show:
-    def getEvent: TradeEvent = evt.fold[TradeEvent](identity, identity)
-
-  object Switch:
-    def from(evt: TradeEvent): Option[Switch] = evt match
-      case e: Started => Switch(e.asLeft).some
-      case e: Stopped => Switch(e.asRight).some
-      case _          => none
-
-    given Eq[Switch] = Eq.by(_.getEvent)
-
   // EventId and Timestamp are regenerated when reprocessed so we don't consider them for deduplication.
-  given Eq[TradeEvent] = Eq.and(Eq.by(_.cid), Eq.by(_Command.get))
-
-  val _Command =
-    Getter[TradeEvent, Option[TradeCommand]] {
-      case e: CommandExecuted => e.command.some
-      case e: CommandRejected => e.command.some
-      case _                  => none
-    }
+  given Eq[TradeEvent] = Eq.and(Eq.by(_.cid), Eq.by(_.command))
 
   val _CorrelationId: Traversal[TradeEvent, CorrelationId] = new:
     def modifyA[F[_]: Applicative](f: CorrelationId => F[CorrelationId])(s: TradeEvent): F[TradeEvent] =
@@ -70,6 +41,4 @@ object TradeEvent:
         s match
           case c: CommandExecuted => c.copy(cid = newCid)
           case c: CommandRejected => c.copy(cid = newCid)
-          case c: Started         => c.copy(cid = newCid)
-          case c: Stopped         => c.copy(cid = newCid)
       }

--- a/modules/feed/src/main/scala/trading/feed/Main.scala
+++ b/modules/feed/src/main/scala/trading/feed/Main.scala
@@ -28,6 +28,14 @@ object Main extends IOApp.Simple:
       .withShardKey(Shard[TradeCommand].key)
       .some
 
+  // SwitchEvent producer settings, dedup and partitioned (for topic compaction)
+  val swSettings =
+    PulsarProducer
+      .Settings[IO, SwitchCommand]()
+      .withDeduplication(SeqIdMaker.fromEq)
+      .withMessageKey(Partition[SwitchCommand].key)
+      .some
+
   // ForecastCommand producer settings, dedup and sharded
   val fcSettings =
     PulsarProducer
@@ -42,8 +50,10 @@ object Main extends IOApp.Simple:
       pulsar <- Pulsar.make[IO](config.pulsar.url)
       _      <- Resource.eval(Logger[IO].info("Initializing feed service"))
       trTopic = AppTopic.TradingCommands.make(config.pulsar)
+      swTopic = AppTopic.SwitchCommands.make(config.pulsar)
       fcTopic = AppTopic.ForecastCommands.make(config.pulsar)
       trading     <- Producer.pulsar[IO, TradeCommand](pulsar, trTopic, tcSettings)
+      switcher    <- Producer.pulsar[IO, SwitchCommand](pulsar, swTopic, swSettings)
       forecasting <- Producer.pulsar[IO, ForecastCommand](pulsar, fcTopic, fcSettings)
       server = Ember.default[IO](config.httpPort)
-    yield server -> Feed.random(trading, forecasting)
+    yield server -> Feed.random(trading, switcher, forecasting)

--- a/modules/processor/src/main/scala/trading/processor/Config.scala
+++ b/modules/processor/src/main/scala/trading/processor/Config.scala
@@ -3,6 +3,7 @@ package trading.processor
 import java.util.UUID
 
 import trading.domain.{ given, * }
+import trading.lib.GenUUID
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*
@@ -13,24 +14,22 @@ import dev.profunktor.pulsar.Config as PulsarConfig
 final case class ProcessorConfig(
     httpPort: Port,
     pulsar: PulsarConfig,
-    redisUri: RedisURI,
     appId: AppId
 )
 
 object Config:
   def load[F[_]: Async]: F[ProcessorConfig] =
-    Async[F].delay(UUID.randomUUID()).flatMap { uuid =>
+    GenUUID[F].make[UUID].flatMap { uuid =>
       (
         env("HTTP_PORT").as[Port].default(port"9003"),
-        env("PULSAR_URI").as[PulsarURI].fallback("pulsar://localhost:6650"),
-        env("REDIS_URI").as[RedisURI].fallback("redis://localhost").covary[F]
-      ).parMapN { (port, pulsarUri, redisUri) =>
+        env("PULSAR_URI").as[PulsarURI].fallback("pulsar://localhost:6650").covary[F]
+      ).parMapN { (port, pulsarUri) =>
         val pulsar =
           PulsarConfig.Builder
             .withTenant("public")
             .withNameSpace("default")
             .withURL(pulsarUri.value)
             .build
-        ProcessorConfig(port, pulsar, redisUri, AppId("processor", uuid))
+        ProcessorConfig(port, pulsar, AppId("processor", uuid))
       }.load[F]
     }

--- a/modules/processor/src/main/scala/trading/processor/Main.scala
+++ b/modules/processor/src/main/scala/trading/processor/Main.scala
@@ -4,11 +4,11 @@ import java.util.UUID
 
 import scala.concurrent.duration.*
 
-import trading.commands.TradeCommand
+import trading.commands.*
 import trading.core.AppTopic
 import trading.core.http.Ember
-import trading.core.snapshots.SnapshotReader
-import trading.events.TradeEvent
+import trading.domain.AppId
+import trading.events.*
 import trading.lib.{ given, * }
 import trading.state.TradeState
 
@@ -22,39 +22,33 @@ object Main extends IOApp.Simple:
   def run: IO[Unit] =
     Stream
       .resource(resources)
-      .flatMap { (server, consumer, events, snapshots, fsm) =>
+      .flatMap { (server, trConsumer, swConsumer, fsm) =>
         Stream.eval(server.useForever).concurrently {
-          Stream.eval(snapshots.latest).flatMap {
-            case Some(st, id) =>
-              val log = Logger[IO].debug(s"Last ID: $id, Status: ${st.status}")
-              val src = consumer.receiveM(id).merge[IO, Engine.In](events)
-              Stream.eval(log) ++ src.evalMapAccumulate(st)(fsm.run)
-            case None =>
-              val src = consumer.receiveM.merge[IO, Engine.In](events)
-              src.evalMapAccumulate(TradeState.empty)(fsm.run)
-          }
+          trConsumer.receiveM
+            .either(swConsumer.receiveM)
+            .evalMapAccumulate(TradeState.empty)(fsm.run)
         }
       }
       .compile
       .drain
 
-  // sharded by symbol (see Shard[TradeCommand] instance)
-  val cmdSub =
+  // TradeCommand subscription, sharded by symbol (see Shard[TradeCommand])
+  def cmdSub(id: AppId) =
     Subscription.Builder
-      .withName("processor")
+      .withName(id.name)
       .withType(Subscription.Type.KeyShared)
       .build
 
-  // TradeEvent.Switch subscription (one per instance, thus the UUID)
-  def swtSub(id: UUID) =
+  // SwitchCommand subscription (one per instance, thus the UUID)
+  def swtSub(id: AppId) =
     Subscription.Builder
-      .withName(s"processor-${id.show}")
+      .withName(id.show)
       .withType(Subscription.Type.Exclusive)
       .build
 
-  // TradeEvent.Switch consumer settings (for topic compaction)
+  // SwitchCommand consumer settings (for topic compaction)
   val compact =
-    PulsarConsumer.Settings[IO, TradeEvent.Switch]().withReadCompacted.some
+    PulsarConsumer.Settings[IO, SwitchCommand]().withReadCompacted.some
 
   // TradeEvent producer settings, dedup and sharded
   val evtSettings =
@@ -64,27 +58,27 @@ object Main extends IOApp.Simple:
       .withShardKey(Shard[TradeEvent].key)
       .some
 
-  // TradeEvent.Switch producer settings, dedup and partitioned (for topic compaction)
+  // SwitchEvent producer settings, dedup and partitioned (for topic compaction)
   val swtSettings =
     PulsarProducer
-      .Settings[IO, TradeEvent.Switch]()
+      .Settings[IO, SwitchEvent]()
       .withDeduplication(SeqIdMaker.fromEq)
-      .withMessageKey(Partition[TradeEvent.Switch].key)
+      .withMessageKey(Partition[SwitchEvent].key)
       .some
 
   def resources =
     for
       config <- Resource.eval(Config.load[IO])
       pulsar <- Pulsar.make[IO](config.pulsar.url, Pulsar.Settings().withTransactions)
-      uuid   <- Resource.eval(GenUUID[IO].make[UUID])
-      _      <- Resource.eval(Logger[IO].info(s"Initializing processor service: ${uuid.show}"))
+      _      <- Resource.eval(Logger[IO].info(s"Initializing service: ${config.appId.show}"))
       server   = Ember.default[IO](config.httpPort)
       cmdTopic = AppTopic.TradingCommands.make(config.pulsar)
       evtTopic = AppTopic.TradingEvents.make(config.pulsar)
-      swtTopic = AppTopic.SwitchEvents.make(config.pulsar)
-      producer  <- Producer.pulsar[IO, TradeEvent](pulsar, evtTopic, evtSettings)
-      switcher  <- Producer.pulsar[IO, TradeEvent.Switch](pulsar, swtTopic, swtSettings)
-      snapshots <- SnapshotReader.make[IO](config.redisUri)
-      consumer  <- Consumer.pulsar[IO, TradeCommand](pulsar, cmdTopic, cmdSub)
-      events    <- Consumer.pulsar[IO, TradeEvent.Switch](pulsar, evtTopic, swtSub(uuid), compact).map(_.receive)
-    yield (server, consumer, events, snapshots, Engine.fsm(producer, switcher, Txn.make(pulsar), consumer.ack))
+      swcTopic = AppTopic.SwitchCommands.make(config.pulsar)
+      sweTopic = AppTopic.SwitchEvents.make(config.pulsar)
+      trProducer <- Producer.pulsar[IO, TradeEvent](pulsar, evtTopic, evtSettings)
+      swProducer <- Producer.pulsar[IO, SwitchEvent](pulsar, sweTopic, swtSettings)
+      trConsumer <- Consumer.pulsar[IO, TradeCommand](pulsar, cmdTopic, cmdSub(config.appId))
+      swConsumer <- Consumer.pulsar[IO, SwitchCommand](pulsar, swcTopic, swtSub(config.appId), compact)
+      engine = Engine.fsm(trProducer, swProducer, Txn.make(pulsar), trConsumer, swConsumer)
+    yield (server, trConsumer, swConsumer, engine)

--- a/modules/snapshots/src/main/scala/trading/snapshots/Engine.scala
+++ b/modules/snapshots/src/main/scala/trading/snapshots/Engine.scala
@@ -4,7 +4,7 @@ import trading.core.TradeEngine
 import trading.core.snapshots.SnapshotWriter
 import trading.lib.{ Acker, FSM, Logger }
 import trading.lib.Consumer.{ Msg, MsgId }
-import trading.events.TradeEvent
+import trading.events.*
 import trading.state.TradeState
 
 import cats.MonadThrow
@@ -13,18 +13,22 @@ import cats.syntax.all.*
 type Tick = Unit
 
 object Engine:
-  type In = Msg[TradeEvent] | Tick
+  type In = Either[Msg[TradeEvent], Msg[SwitchEvent]] | Tick
 
   def fsm[F[_]: MonadThrow: Logger](
-      acker: Acker[F, TradeEvent],
+      tradeAcker: Acker[F, TradeEvent],
+      switchAcker: Acker[F, SwitchEvent],
       writer: SnapshotWriter[F]
   ): FSM[F, (TradeState, List[MsgId]), In, Unit] =
     FSM {
-      case ((st, ids), Msg(msgId, _, TradeEvent.CommandExecuted(eid, _, cmd, _))) =>
+      case ((st, ids), Left(Msg(msgId, _, TradeEvent.CommandExecuted(_, _, cmd, _)))) =>
         ().pure[F].tupleLeft(TradeEngine.fsm.runS(st, cmd) -> (ids :+ msgId))
-      case (st, Msg(msgId, _, evt)) =>
+      case (st, Left(Msg(msgId, _, evt))) =>
         Logger[F].debug(s"Event ID: ${evt.id}, no persistence") *>
-          acker.ack(msgId).attempt.void.tupleLeft(st)
+          tradeAcker.ack(msgId).attempt.void.tupleLeft(st)
+      case ((st, ids), Right(Msg(msgId, _, evt))) =>
+        val nst = evt.getCommand.map(TradeEngine.fsm.runS(st, _)).getOrElse(st)
+        switchAcker.ack(msgId).attempt.void.tupleLeft(nst, ids)
       case ((st, ids), (_: Tick)) if ids.nonEmpty =>
         val lastId = ids.last
         writer
@@ -35,7 +39,7 @@ object Engine:
               Logger[F].warn(s"Failed to persist state: $lastId").tupleLeft(st -> ids)
             case Right(_) =>
               Logger[F].debug(s"State persisted: $lastId. Acking ${ids.size} messages.") *>
-                acker.ack(ids.toSet).attempt.map {
+                tradeAcker.ack(ids.toSet).attempt.map {
                   case Left(_)  => (st -> ids)        -> ()
                   case Right(_) => (st -> List.empty) -> ()
                 }


### PR DESCRIPTION
Extracting out the `Start` / `Stop` commands into their own type `SwitchCommand`, and `Started` / `Stopped` events into `SwitchEvent`, makes a lot of things easier. 

The most remarkable one is the possibility of having a `KeyShared` subscription for trading commands and events, and an `Exclusive` subscription per instance for switch commands and events. Also, since the switch is basically represented as either `On` or `Off`, we can keep a compacted topic where always the latest state is what matters most.

---

Another unrelated change that stemmed from this fact is the realization that `processor` does not need to read snapshots. As a sharded service, instances will always pick up the latest commands and run them through the FSM, but there are no computations of prices whatsoever, so this was unnecessary.

A `processor` instance will consume `TradeCommand`s and simply produce `TradeEvent`s. The only essential data in this case is the trading status, which dictates what `TradeEvent` / `SwitchEvent` is generated from an input command, and we have this covered thanks to a new `switch-commands` compacted topic.

Both `alerts` and `snapshots` services still require snapshots. The former manipulates prices per symbol, and the latter to continue writing new snapshots from a sane state. This is a lot to update in the book, but I feel we're in the right path.