### PR TITLE
alerts: key-shared subscription that handles rebalancing

### DIFF
--- a/modules/core/src/main/scala/trading/core/AppTopic.scala
+++ b/modules/core/src/main/scala/trading/core/AppTopic.scala
@@ -27,6 +27,10 @@ object AppTopic:
     val name: String                    = "switch-events"
     def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
 
+  case object PriceUpdates extends AppTopic:
+    val name: String                    = "price-updates"
+    def make(cfg: Config): Topic.Single = mkPersistent(cfg, name)
+
   case object ForecastCommands extends AppTopic:
     val name: String                    = "forecast-commands"
     def make(cfg: Config): Topic.Single = mkNonPersistent(cfg, name)

--- a/modules/domain/jvm/src/test/scala/trading/domain/PriceUpdateCodecSuite.scala
+++ b/modules/domain/jvm/src/test/scala/trading/domain/PriceUpdateCodecSuite.scala
@@ -1,0 +1,16 @@
+package trading.domain
+
+import trading.state.Prices
+
+import io.circe.parser.decode as jsonDecode
+import io.circe.syntax.*
+import weaver.FunSuite
+
+object PriceUpdateCodecSuite extends FunSuite:
+
+  test("codec roundtrip for PriceUpdate") {
+    val p   = PriceUpdate(Symbol.EURUSD, Prices(Map.empty, Map(Price(2.3) -> Quantity(45)), Price(2.7), Price(7.5)))
+    val enc = p.asJson.noSpaces
+    val dec = jsonDecode[PriceUpdate](enc)
+    expect.same(Right(p), dec)
+  }

--- a/modules/domain/shared/src/main/scala/trading/domain/PriceUpdate.scala
+++ b/modules/domain/shared/src/main/scala/trading/domain/PriceUpdate.scala
@@ -1,0 +1,13 @@
+package trading.domain
+
+import trading.state.Prices
+
+import cats.{ Eq, Show }
+// FIXME: importing * does not work
+import cats.derived.semiauto.{ derived, product, productOrder }
+import io.circe.Codec
+
+final case class PriceUpdate(
+    symbol: Symbol,
+    prices: Prices
+) derives Codec.AsObject, Eq, Show

--- a/modules/lib/src/main/scala/trading/lib/Partition.scala
+++ b/modules/lib/src/main/scala/trading/lib/Partition.scala
@@ -1,7 +1,7 @@
 package trading.lib
 
 import trading.commands.SwitchCommand
-import trading.domain.Alert
+import trading.domain.{ Alert, PriceUpdate }
 import trading.events.SwitchEvent
 
 import cats.syntax.all.*
@@ -17,6 +17,9 @@ object Partition:
     val key: A => MessageKey = _ => MessageKey.Empty
 
   def by(s: String): MessageKey = MessageKey.Of(s)
+
+  given Partition[PriceUpdate] with
+    val key: PriceUpdate => MessageKey = p => by(p.symbol.show)
 
   given Partition[SwitchCommand] with
     val key: SwitchCommand => MessageKey = {


### PR DESCRIPTION
We have three options:

1. Use `Failover` subscription type. Simple, but doesn't scale.
2. Use [sticky consistent hashing](https://medium.com/@ankushkhanna1988/apache-pulsar-key-shared-mode-sticky-consistent-hashing-a4ee7133930a) (properly supported since Pulsar 2.7.0). Requires a fixed number of instances, which means potential downtime when one instance crashes or on deployment. Hard to maintain.
3. Update every instance with the price updates, so when the number of instances change and Pulsar triggers a consumers' rebalancing, every instance knows the latest prices of a specific symbol previously handled by other instance.

In practice, instances should be up 99.9% of the time, so this is just to handle that 0.1% of the time when a rebalance gets triggered (usually on roll-out deployment or on crash).