### PR TITLE
fix shell after unifying flakes

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,3 @@
-{ system ? builtins.currentSystem or "unknown-system" }:
+{ system ? builtins.currentSystem or "unknown-system", shell ? "scala" }:
 
-(builtins.getFlake ("git+file://" + toString ./.)).devShell.${system}
+(builtins.getFlake ("git+file://" + toString ./.)).devShells.${system}.${shell}


### PR DESCRIPTION
hey, #211 broke the `shell.nix` pointer to development shell.

also, nix-direnv throws an error
```
error: '' needs to evaluate to a single derivation, but it evaluated to 3 derivations
```
so it's required to specify the exact shell now (`echo "use-flake .#scala" > .envrc`).