### PR TITLE
lint: update scalafmt and scalafix configurations

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,7 @@
 OrganizeImports {
-  groupedImports                    = Keep
-  groups                            = ["re:javax?\\.", "scala.", "trading.", "*"]
-  removeUnused                      = false
+  groupedImports       = Keep
+  groups               = ["re:javax?\\.", "scala.", "trading.", "*"]
+  removeUnused         = false
+  importSelectorsOrder = Keep
+  importsOrder         = Keep
 }

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,38 @@
-runner.dialect             = scala3
-version                    = "3.0.6"
-align.preset               = more
-maxColumn                  = 120
-rewrite.rules              = [AsciiSortImports]
-spaces.inImportCurlyBraces = true
+runner.dialect = scala3
+version = "3.6.1"
+maxColumn = 120
+
+newlines.source = keep
+
+rewrite {
+  rules = [Imports]
+  imports.sort = ascii
+}
+
+rewrite.scala3 {
+  convertToNewSyntax = yes
+  removeOptionalBraces = yes
+}
+
+align {
+  allowOverflow = true
+  preset = more
+  openParenCallSite = false
+  stripMargin = true
+}
+
+continuationIndent {
+  callSite = 2
+  defnSite = 4
+}
+
+docstrings {
+  style = Asterisk
+  oneline = keep
+  wrap = no
+}
+
+spaces {
+  beforeContextBoundColon = Never
+  inImportCurlyBraces = true
+}

--- a/modules/alerts/src/main/scala/trading/alerts/Config.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Config.scala
@@ -2,7 +2,7 @@ package trading.alerts
 
 import java.util.UUID
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 import trading.lib.GenUUID
 
 import cats.effect.kernel.Async

--- a/modules/alerts/src/main/scala/trading/alerts/Main.scala
+++ b/modules/alerts/src/main/scala/trading/alerts/Main.scala
@@ -5,7 +5,7 @@ import trading.core.http.Ember
 import trading.core.snapshots.SnapshotReader
 import trading.domain.{ Alert, AppId, PriceUpdate }
 import trading.events.*
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 import trading.state.TradeState
 
 import cats.effect.*

--- a/modules/domain/shared/src/main/scala/trading/commands/ForecastCommand.scala
+++ b/modules/domain/shared/src/main/scala/trading/commands/ForecastCommand.scala
@@ -1,8 +1,6 @@
 package trading.commands
 
-import trading.domain.{ given, * }
-import trading.domain.ForecastTag.given // to derive Eq (should not be needed, though)
-import trading.domain.VoteResult.given  // to derive Eq (should not be needed, though)
+import trading.domain.{ *, given }
 
 import cats.{ Applicative, Eq, Show }
 import cats.derived.*

--- a/modules/domain/shared/src/main/scala/trading/commands/SwitchCommand.scala
+++ b/modules/domain/shared/src/main/scala/trading/commands/SwitchCommand.scala
@@ -1,6 +1,6 @@
 package trading.commands
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.{ Applicative, Eq, Show }
 import cats.derived.*

--- a/modules/domain/shared/src/main/scala/trading/commands/TradeCommand.scala
+++ b/modules/domain/shared/src/main/scala/trading/commands/TradeCommand.scala
@@ -1,6 +1,6 @@
 package trading.commands
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.{ Applicative, Eq, Show }
 import cats.derived.*

--- a/modules/domain/shared/src/main/scala/trading/events/SwitchEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/SwitchEvent.scala
@@ -1,7 +1,7 @@
 package trading.events
 
 import trading.commands.SwitchCommand
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.{ Applicative, Show }
 import cats.derived.*

--- a/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
+++ b/modules/domain/shared/src/main/scala/trading/events/TradeEvent.scala
@@ -1,7 +1,7 @@
 package trading.events
 
 import trading.commands.TradeCommand
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.{ Applicative, Eq, Show }
 import cats.derived.*

--- a/modules/feed/src/main/scala/trading/feed/Config.scala
+++ b/modules/feed/src/main/scala/trading/feed/Config.scala
@@ -1,6 +1,6 @@
 package trading.feed
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*

--- a/modules/feed/src/main/scala/trading/feed/ForecastFeed.scala
+++ b/modules/feed/src/main/scala/trading/feed/ForecastFeed.scala
@@ -10,7 +10,7 @@ import trading.core.AppTopic
 import trading.domain.*
 import trading.domain.generators.*
 import trading.events.*
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 
 import cats.effect.*
 import cats.effect.syntax.all.*

--- a/modules/forecasts/src/main/scala/trading/forecasts/Config.scala
+++ b/modules/forecasts/src/main/scala/trading/forecasts/Config.scala
@@ -2,7 +2,7 @@ package trading.forecasts
 
 import scala.concurrent.duration.*
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*

--- a/modules/forecasts/src/main/scala/trading/forecasts/Main.scala
+++ b/modules/forecasts/src/main/scala/trading/forecasts/Main.scala
@@ -6,7 +6,7 @@ import trading.core.http.Ember
 import trading.events.*
 import trading.forecasts.cdc.*
 import trading.forecasts.store.*
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 
 import cats.effect.*
 import cats.effect.syntax.all.*

--- a/modules/lib/src/main/scala/trading/lib/Compaction.scala
+++ b/modules/lib/src/main/scala/trading/lib/Compaction.scala
@@ -7,11 +7,12 @@ import trading.events.SwitchEvent
 import cats.syntax.all.*
 import dev.profunktor.pulsar.{ MessageKey, ShardKey }
 
-/** A compaction key corresponds to the (partitioning) `key` of a Pulsar `Message`, which is used for topic compaction
-  * as well as for routing messages when the `orderingKey` is absent.
-  *
-  * For `KeyShared` subscriptions, see the [[Shard]] typeclass.
-  */
+/**
+ * A compaction key corresponds to the (partitioning) `key` of a Pulsar `Message`, which is used for topic compaction
+ * as well as for routing messages when the `orderingKey` is absent.
+ *
+ * For `KeyShared` subscriptions, see the [[Shard]] typeclass.
+ */
 trait Compaction[A]:
   def key: A => MessageKey
 

--- a/modules/lib/src/main/scala/trading/lib/Consumer.scala
+++ b/modules/lib/src/main/scala/trading/lib/Consumer.scala
@@ -25,7 +25,7 @@ trait Consumer[F[_], A] extends Acker[F, A]:
   def lastMsgId: F[Option[Consumer.MsgId]]
 
 object Consumer:
-  //Pulsar: MessageId(ledgerId: Long, entryId: Long, partitionIndex: Int)
+  // Pulsar: MessageId(ledgerId: Long, entryId: Long, partitionIndex: Int)
   enum MsgId:
     case Pulsar(id: MessageId)
     case Dummy

--- a/modules/lib/src/main/scala/trading/lib/Shard.scala
+++ b/modules/lib/src/main/scala/trading/lib/Shard.scala
@@ -9,11 +9,12 @@ import trading.events.TradeEvent
 import cats.syntax.all.*
 import dev.profunktor.pulsar.ShardKey
 
-/** A shard corresponds to the `orderingKey` of a Pulsar `Message`, which is used for routing in `KeyShared`
-  * subscriptions.
-  *
-  * For topic compaction, see the [[Compaction]] typeclass.
-  */
+/**
+ * A shard corresponds to the `orderingKey` of a Pulsar `Message`, which is used for routing in `KeyShared`
+ * subscriptions.
+ *
+ * For topic compaction, see the [[Compaction]] typeclass.
+ */
 trait Shard[A]:
   def key: A => ShardKey
 

--- a/modules/lib/src/main/scala/trading/lib/ext.scala
+++ b/modules/lib/src/main/scala/trading/lib/ext.scala
@@ -42,51 +42,53 @@ extension [F[_], A, B, C](src: Stream[F, Either[Either[Msg[A], Msg[B]], Msg[C]]]
     }
 
 extension [F[_]: MonadThrow, A <: Matchable](fa: F[A])
-  /** Lift an F[A] into an F[Either[E, A]] where E can be an union type.
-    *
-    * Guarantees that:
-    *
-    * {{{
-    * val fa: F[A] = ???
-    * fa <-> fa.lift[E].rethrow
-    * }}}
-    *
-    * Example:
-    *
-    * {{{
-    * case class Err1() extends NoStackTrace
-    * case class Err2() extends NoStackTrace
-    *
-    * val f: IO[Unit] = IO.raiseError(Err1())
-    * val g: IO[Either[Err1, Unit]] = f.lift
-    * val h: IO[Either[Err1 | Err2, Unit]] = f.lift
-    * val i: IO[Unit] = h.rethrow
-    * }}}
-    */
+  /**
+   * Lift an F[A] into an F[Either[E, A]] where E can be an union type.
+   *
+   * Guarantees that:
+   *
+   * {{{
+   * val fa: F[A] = ???
+   * fa <-> fa.lift[E].rethrow
+   * }}}
+   *
+   * Example:
+   *
+   * {{{
+   * case class Err1() extends NoStackTrace
+   * case class Err2() extends NoStackTrace
+   *
+   * val f: IO[Unit] = IO.raiseError(Err1())
+   * val g: IO[Either[Err1, Unit]] = f.lift
+   * val h: IO[Either[Err1 | Err2, Unit]] = f.lift
+   * val i: IO[Unit] = h.rethrow
+   * }}}
+   */
   def lift[E <: Throwable: ClassTag]: F[Either[E, A]] =
     fa.attemptNarrow
 
-  /** Same as `lift`, excepts the resulting type uses `E | A` instead of `Either[E, A]`.
-    *
-    * Guarantees that:
-    *
-    * {{{
-    * val fa: F[A] = ???
-    * fa <-> fa.liftU[E].rethrow
-    * }}}
-    *
-    * Example:
-    *
-    * {{{
-    * case class Err1() extends NoStackTrace
-    * case class Err2() extends NoStackTrace
-    *
-    * val f: IO[Unit] = IO.raiseError(Err1())
-    * val g: IO[Err1 | Unit] = f.liftU
-    * val h: IO[Err1 | Err2 | Unit] = f.liftU
-    * val i: IO[Unit] = h.rethrow
-    * }}}
-    */
+  /**
+   * Same as `lift`, excepts the resulting type uses `E | A` instead of `Either[E, A]`.
+   *
+   * Guarantees that:
+   *
+   * {{{
+   * val fa: F[A] = ???
+   * fa <-> fa.liftU[E].rethrow
+   * }}}
+   *
+   * Example:
+   *
+   * {{{
+   * case class Err1() extends NoStackTrace
+   * case class Err2() extends NoStackTrace
+   *
+   * val f: IO[Unit] = IO.raiseError(Err1())
+   * val g: IO[Err1 | Unit] = f.liftU
+   * val h: IO[Err1 | Err2 | Unit] = f.liftU
+   * val i: IO[Unit] = h.rethrow
+   * }}}
+   */
   def liftU[E <: Throwable: ClassTag]: F[E | A] =
     lift.map(eitherUnionIso[E, A].get)
 

--- a/modules/processor/src/main/scala/trading/processor/Config.scala
+++ b/modules/processor/src/main/scala/trading/processor/Config.scala
@@ -2,7 +2,7 @@ package trading.processor
 
 import java.util.UUID
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 import trading.lib.GenUUID
 
 import cats.effect.kernel.Async

--- a/modules/processor/src/main/scala/trading/processor/Main.scala
+++ b/modules/processor/src/main/scala/trading/processor/Main.scala
@@ -9,7 +9,7 @@ import trading.core.AppTopic
 import trading.core.http.Ember
 import trading.domain.AppId
 import trading.events.*
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 import trading.state.TradeState
 
 import cats.effect.*

--- a/modules/snapshots/src/main/scala/trading/snapshots/Config.scala
+++ b/modules/snapshots/src/main/scala/trading/snapshots/Config.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import scala.concurrent.duration.*
 
-import trading.domain.{ given, * }
+import trading.domain.{ *, given }
 import trading.lib.GenUUID
 
 import cats.effect.kernel.Async

--- a/modules/snapshots/src/main/scala/trading/snapshots/Main.scala
+++ b/modules/snapshots/src/main/scala/trading/snapshots/Main.scala
@@ -7,7 +7,7 @@ import trading.core.snapshots.{ SnapshotReader, SnapshotWriter }
 import trading.core.{ AppTopic, TradeEngine }
 import trading.domain.AppId
 import trading.events.{ SwitchEvent, TradeEvent }
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 import trading.lib.Consumer.{ Msg, MsgId }
 import trading.state.TradeState
 

--- a/modules/tracing/src/main/scala/trading/trace/Config.scala
+++ b/modules/tracing/src/main/scala/trading/trace/Config.scala
@@ -2,7 +2,7 @@ package trading.trace
 
 import scala.concurrent.duration.*
 
-import trading.domain.{*, given}
+import trading.domain.{ *, given }
 import trading.Newtype
 
 import cats.effect.kernel.Async

--- a/modules/tracing/src/main/scala/trading/trace/Main.scala
+++ b/modules/tracing/src/main/scala/trading/trace/Main.scala
@@ -8,7 +8,7 @@ import trading.core.http.Ember
 import trading.core.snapshots.SnapshotReader
 import trading.domain.Alert
 import trading.events.*
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 import trading.trace.fsm.*
 import trading.trace.tracer.*
 

--- a/modules/ws-server/src/main/scala/trading/ws/Config.scala
+++ b/modules/ws-server/src/main/scala/trading/ws/Config.scala
@@ -1,6 +1,6 @@
 package trading.ws
 
-import trading.domain.{*, given}
+import trading.domain.{ *, given }
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*

--- a/modules/x-demo/src/main/scala/demo/DepTypes.scala
+++ b/modules/x-demo/src/main/scala/demo/DepTypes.scala
@@ -38,9 +38,10 @@ val _cat = Graph.make[String](List.empty)
 val _dog = Graph.make[Int](Vector.empty)
 val _fox = Graph.make[Long](Set.empty)
 
-/** the following does not compile as we do not declare a match type for Long
-  *
-  * [error] dotty.tools.dotc.core.TypeError: Match type reduction failed since selector Long [error] matches none of the
-  * cases [error] [error] case String => List[String] [error] case Int => Vector[Int]
-  */
+/**
+ * the following does not compile as we do not declare a match type for Long
+ *
+ * [error] dotty.tools.dotc.core.TypeError: Match type reduction failed since selector Long [error] matches none of the
+ * cases [error] [error] case String => List[String] [error] case Int => Vector[Int]
+ */
 //val nope = Graph.make[Long]

--- a/modules/x-demo/src/main/scala/demo/DerivationDemo.scala
+++ b/modules/x-demo/src/main/scala/demo/DerivationDemo.scala
@@ -13,7 +13,7 @@ import io.circe.syntax.*
 
 @main def jsonDerivationDemo =
   val address = Address("Baker", 221, Some("B"))
-  val json = address.asJson.spaces2
+  val json    = address.asJson.spaces2
   println(json)
   assert(jsonDecode[Address](json) == Right(address))
 

--- a/modules/x-demo/src/main/scala/demo/EffectfulContext.scala
+++ b/modules/x-demo/src/main/scala/demo/EffectfulContext.scala
@@ -21,11 +21,12 @@ object EffectfulContext extends IOApp.Simple:
       log: Log
   )
 
-  private val mkCtx = for
-    id <- Resource.eval(IO(UUID.randomUUID()))
-    sp <- Supervisor[IO]
-    lg <- Resource.eval(Ref.of[IO, List[String]](List.empty))
-  yield Ctx(id, sp, Log(lg))
+  private val mkCtx =
+    for
+      id <- Resource.eval(IO(UUID.randomUUID()))
+      sp <- Supervisor[IO]
+      lg <- Resource.eval(Ref.of[IO, List[String]](List.empty))
+    yield Ctx(id, sp, Log(lg))
 
   def withCtx(f: Ctx ?=> IO[Unit]): IO[Unit] =
     mkCtx.use { ctx =>

--- a/modules/x-demo/src/main/scala/demo/IronDemo.scala
+++ b/modules/x-demo/src/main/scala/demo/IronDemo.scala
@@ -7,7 +7,7 @@ import cats.syntax.all.*
 import io.circe.*
 import io.circe.syntax.*
 import io.github.iltotore.iron.*
-import io.github.iltotore.iron.cats.{ given, * }
+import io.github.iltotore.iron.cats.{ *, given }
 import io.github.iltotore.iron.circe.given
 import io.github.iltotore.iron.constraint.all.*
 

--- a/modules/x-demo/src/main/scala/demo/PulsarCDC.scala
+++ b/modules/x-demo/src/main/scala/demo/PulsarCDC.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration.*
 
 import trading.domain.*
 import trading.lib.{ Consumer, Logger }
-import trading.lib.Logger.NoOp.given // comment this line if you'd like to see the incoming Pulsar messages
+import trading.lib.Logger.NoOp.given
 
 import cats.effect.*
 import cats.effect.syntax.all.*
@@ -21,8 +21,11 @@ import doobie.postgres.implicits.*
 import fs2.Stream
 import io.circe.Codec
 
-/* A little application that inserts three different records in the authors table,
+/*
+ * A little application that inserts three different records in the authors table,
  * and a Pulsar consumer receiving data from the Debezium Postgres connector.
+ *
+ * Comment out the `Logger.NoOp.given` import to see incoming Pulsar messages.
  */
 object PulsarCDC extends IOApp.Simple:
   def run: IO[Unit] =
@@ -51,7 +54,7 @@ object PulsarCDC extends IOApp.Simple:
 
   val config = PulsarConfig.Builder.default
 
-  //FORMAT: persistent://public/default/${database.server.name}.${schema}.${table}
+  // FORMAT: persistent://public/default/${database.server.name}.${schema}.${table}
   val topic =
     Topic.Builder
       .withName(Topic.Name("dbserver.public.authors"))

--- a/modules/x-demo/src/main/scala/demo/dedup/Conflicts.scala
+++ b/modules/x-demo/src/main/scala/demo/dedup/Conflicts.scala
@@ -17,4 +17,3 @@ object Conflicts:
 
   def updateMany(ds: DedupState)(commands: List[TradeCommand], ts: Timestamp): DedupState =
     DedupState(ds.removeOld(ts) ++ commands.map(c => IdRegistry(c.id, ts)).toSet)
-

--- a/modules/x-demo/src/main/scala/demo/dedup/DedupRegistry.scala
+++ b/modules/x-demo/src/main/scala/demo/dedup/DedupRegistry.scala
@@ -18,17 +18,18 @@ trait DedupRegistry[F[_]]:
   def get: F[DedupState]
   def save(state: DedupState): F[Unit]
 
-/** Registry of processed ids per application.
-  *
-  * The `get` function returns the union of all the sets of command ids that have been processed by all the instances of
-  * the app (service).
-  *
-  * The `save` function persists the processed command ids of the current app instance, uniquely identified by its name
-  * and id.
-  *
-  * Upon reading the keys, we reset all the ids' timestamp to make things easier, as we can avoid persisting everything
-  * since these are short-lived and will expire either way.
-  */
+/**
+ * Registry of processed ids per application.
+ *
+ * The `get` function returns the union of all the sets of command ids that have been processed by all the instances of
+ * the app (service).
+ *
+ * The `save` function persists the processed command ids of the current app instance, uniquely identified by its name
+ * and id.
+ *
+ * Upon reading the keys, we reset all the ids' timestamp to make things easier, as we can avoid persisting everything
+ * since these are short-lived and will expire either way.
+ */
 object DedupRegistry:
   def from[F[_]: MonadThrow: Time](
       redis: RedisCommands[F, String, String],
@@ -64,4 +65,3 @@ object DedupRegistry:
       exp: KeyExpiration
   ): Resource[F, DedupRegistry[F]] =
     RedisClient[F].from(uri.value).flatMap(fromClient[F](_, appId, exp))
-

--- a/modules/x-demo/src/main/scala/demo/tracer/Engine.scala
+++ b/modules/x-demo/src/main/scala/demo/tracer/Engine.scala
@@ -2,11 +2,10 @@ package demo.tracer
 
 import java.util.UUID
 
-import demo.tracer.db.*
-
 import trading.lib.Consumer.{ Msg, MsgId }
 import trading.lib.{ GenUUID, Producer }
 
+import demo.tracer.db.*
 import cats.Monad
 import cats.syntax.all.*
 import natchez.Trace

--- a/modules/x-demo/src/main/scala/demo/tracer/TraceApp.scala
+++ b/modules/x-demo/src/main/scala/demo/tracer/TraceApp.scala
@@ -9,7 +9,7 @@ import demo.tracer.http.*
 export demo.tracer.NT.syntax.*
 
 import trading.core.http.Ember
-import trading.lib.{ given, * }
+import trading.lib.{ *, given }
 import trading.lib.Consumer.Msg
 import trading.trace.tracer.Honeycomb
 
@@ -103,7 +103,8 @@ object TraceApp extends IOApp.Simple:
             val runner =
               names(
                 nameConsumer,
-                (msg, sp) => Engine.one[Eff](userProducer, db, id => Kleisli.liftF(nameConsumer.ack(id))).apply(msg).run(sp)
+                (msg, sp) =>
+                  Engine.one[Eff](userProducer, db, id => Kleisli.liftF(nameConsumer.ack(id))).apply(msg).run(sp)
               )
 
             Stream(

--- a/modules/x-demo/src/main/scala/demo/tracer/http/Routes.scala
+++ b/modules/x-demo/src/main/scala/demo/tracer/http/Routes.scala
@@ -3,9 +3,9 @@ package http
 
 import java.util.UUID
 
-import demo.tracer.db.*
 import trading.lib.GenUUID
 
+import demo.tracer.db.*
 import cats.Monad
 import cats.syntax.all.*
 import natchez.Trace


### PR DESCRIPTION
Running `scalafmtAll` and `lint` don't conflict with each other anymore.