### PR TITLE
Upgrade http4s & http4s-jdk-http-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ val commonSettings = List(
     Libraries.fs2Core.value,
     Libraries.kittens.value,
     Libraries.ip4sCore.value,
+    Libraries.log4catsNoop,
     Libraries.monocleCore.value,
     Libraries.catsLaws         % Test,
     Libraries.monocleLaw       % Test,

--- a/modules/x-qa/src/test/scala/smokey/Smokey.scala
+++ b/modules/x-qa/src/test/scala/smokey/Smokey.scala
@@ -14,6 +14,7 @@ import trading.lib.{ Producer, Shard }
 import trading.ws.*
 
 import cats.effect.*
+import cats.effect.syntax.*
 import cats.syntax.all.*
 import dev.profunktor.pulsar.{ Config, Producer as PulsarProducer, Pulsar }
 import fs2.Stream
@@ -31,7 +32,7 @@ object Smokey extends IOSuite:
   val connectReq = WSRequest(uri"ws://localhost:9000/v1/ws")
 
   override def sharedResource: Resource[IO, Res] =
-    (Pulsar.make[IO](pulsarCfg.url), JdkWSClient.simple[IO]).tupled
+    (Pulsar.make[IO](pulsarCfg.url), JdkWSClient.simple[IO].toResource).tupled
 
   val symbols1: List[WsIn] = List(EURUSD, USDCAD, GBPUSD).map(WsIn.Subscribe(_))
   val symbols2: List[WsIn] = List(EURPLN, CHFEUR).map(WsIn.Subscribe(_))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val fs2Kafka      = "3.0.1"
     val http4s        = "1.0.0-M40"
     val http4sMetrics = "1.0.0-M38"
-    val http4sWs      = "1.0.0-M3"
+    val http4sWs      = "1.0.0-M9"
     val ip4s          = "3.3.0"
     val iron          = "2.2.1"
     val kittens       = "3.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,12 +12,13 @@ object Dependencies {
     val flyway        = "8.5.13"
     val fs2Core       = "3.9.1"
     val fs2Kafka      = "3.0.1"
-    val http4s        = "1.0.0-M39"
+    val http4s        = "1.0.0-M40"
     val http4sMetrics = "1.0.0-M38"
     val http4sWs      = "1.0.0-M3"
     val ip4s          = "3.3.0"
     val iron          = "2.2.1"
     val kittens       = "3.0.0"
+    val log4cats      = "2.6.0"
     val monocle       = "3.2.0"
     val natchez       = "0.3.3"
     val natchezHttp4s = "0.5.0"
@@ -30,7 +31,7 @@ object Dependencies {
     val tyrian      = "0.6.1"
 
     val scalacheck = "1.17.0"
-    val weaver     = "0.8.2"
+    val weaver     = "0.8.3"
 
     val organizeImports = "0.6.0"
     val zerowaste       = "0.2.12"
@@ -81,6 +82,9 @@ object Dependencies {
     val monocleCore = Def.setting("dev.optics" %%% "monocle-core" % V.monocle)
 
     val odin = "com.github.valskalla" %% "odin-core" % V.odin
+
+    // only for ember
+    val log4catsNoop = "org.typelevel" %% "log4cats-noop" % V.log4cats
 
     // webapp
     val scalajsTime = Def.setting("io.github.cquiroz" %%% "scala-java-time" % V.scalajsTime)


### PR DESCRIPTION
With the upgrade of `http4s`, smoke tests break, as reported on #285 . Output:

```console
<<< WS conn error: Output closed
<<< WS conn error: Output closed
2023-09-03T19:27:41,654 [io-compute-1] INFO trading.lib.Logger - {"flow":"out","payload":{"Create":{"id":"2b23aa5a-78ac-449b-9d69-d9633be03d60","cid":"cb35e68d-a269-42a9-92e7-77cc4fd891f5","symbol":"EURUSD","tradeAction":{"Ask":{}},"price":4.5,"quantity":10,"source":"test","createdAt":"2023-09-03T17:27:38.486297230Z"}},"topic":"persistent://public/default/trading-commands"}
2023-09-03T19:27:41,738 [io-compute-5] INFO trading.lib.Logger - {"flow":"out","payload":{"Create":{"id":"d71a5642-4c61-45a0-b699-c48ae33bf35b","cid":"2c637f0a-6a22-4667-8c65-50e7f696aadd","symbol":"CHFEUR","tradeAction":{"Ask":{}},"price":2.3,"quantity":55,"source":"test","createdAt":"2023-09-03T17:27:38.486297230Z"}},"topic":"persistent://public/default/trading-commands"}
2023-09-03T19:27:41,838 [io-compute-10] INFO trading.lib.Logger - {"flow":"out","payload":{"Create":{"id":"0150a458-f81e-4b5a-9b34-7ff50eaf58cb","cid":"0d538820-1c11-40e1-b809-ff1ffa07b89f","symbol":"USDCAD","tradeAction":{"Bid":{}},"price":3.7,"quantity":7,"source":"test","createdAt":"2023-09-03T17:27:38.486297230Z"}},"topic":"persistent://public/default/trading-commands"}
2023-09-03T19:27:41,938 [io-compute-5] INFO trading.lib.Logger - {"flow":"out","payload":{"Create":{"id":"10b0fb67-0817-4478-9534-265fc14890bf","cid":"e94f19b4-8504-4098-8a02-7e55c6afdbc2","symbol":"GBPUSD","tradeAction":{"Bid":{}},"price":2.6,"quantity":89,"source":"test","createdAt":"2023-09-03T17:27:38.486297230Z"}},"topic":"persistent://public/default/trading-commands"}
2023-09-03T19:27:42,38 [io-compute-8] INFO trading.lib.Logger - {"flow":"out","payload":{"Update":{"id":"2c704372-d5bf-48c8-a49f-ba47a3346735","cid":"f97c8bb0-1c3c-4862-9750-3c24ff1c79f1","symbol":"GBPUSD","tradeAction":{"Bid":{}},"price":2.8,"quantity":24,"source":"test","createdAt":"2023-09-03T17:27:38.486297230Z"}},"topic":"persistent://public/default/trading-commands"}

--- WsOut list ---
List()
[info] smokey.Smokey
[info] - Trading smoke test 3s
[info] *************FAILURES**************
[info] smokey.Smokey
[error] - Trading smoke test 3s
[error]   Expected 5 messages (modules/x-qa/src/test/scala/smokey/Smokey.scala:138)
[error]
[error] Failed: Total 1, Failed 1, Errors 0, Passed 0
[error] Failed tests:
[error] 	smokey.Smokey
[error] (smokey / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 6 s, completed Sep 3, 2023, 7:27:44 PM
```

---

UPDATE: upgrading `http4s-jdk-http-client` to the latest `1.0.0-M9` fixes the issue.

---

closes #277 
closes #267